### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ transcription directly in the browser.
 ## Running the App
 
 Simply open `index.html` in a modern browser. For development you can use a
-basic HTTP server such as Python's built‑in module:
+basic HTTP server such as Python's built‑in module or the included npm script:
 
 ```bash
 python3 -m http.server 8000
 ```
+
+```bash
+npm start
+```
+This command uses `http-server` to serve the project on port 8000.
 
 Then navigate to <http://localhost:8000/> or the appropriate HTTPS address.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A minimal prototype (MVP) of the SeñAR app. This single page web application provides sign language recognition features and audio transcription directly in the browser.",
   "main": "app.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "npx http-server . -p 8000"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add an http-server based `npm start` script
- document `npm start` in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ed12d5148331b29aa9126171d1a5