### PR TITLE
Implement offline script and persistent settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ transcription directly in the browser.
 * Transcripción de voz a texto usando la API Web Speech o el modelo
   **Whisper tiny** a través de **Transformers**.
 * Interfaz con subtítulos arrastrables, cambio de tema y recorrido guiado.
+* Las preferencias de tema y tamaño de subtítulos se guardan en el navegador.
 * Herramientas para capturar imágenes y alternar cámaras durante la sesión.
 
 ## Prerequisites
@@ -72,12 +73,9 @@ estáticos a través de un servidor local como se muestra arriba.
 
 Para ejecutar la demo sin conexión:
 
-1. Cree una carpeta `libs/` en la raíz del proyecto.
-2. Descargue de jsDelivr los archivos `hands.js`, `face_mesh.js`, `pose.js` y `drawing_utils.js`
-   de **MediaPipe** y guárdelos en `libs/`.
-3. Obtenga `transformers.min.js` desde el paquete de **Transformers** (versión 3.5.2)
-   y colóquelo en la misma carpeta.
-4. Modifique las etiquetas `<script>` de `index.html` para que apunten a los
+1. Ejecute `npm run prepare-offline` para descargar los modelos y crear
+   la carpeta `libs/` automáticamente.
+2. Modifique las etiquetas `<script>` de `index.html` para que apunten a los
    archivos locales, por ejemplo:
    ```html
    <script src="libs/hands.js"></script>
@@ -85,13 +83,13 @@ Para ejecutar la demo sin conexión:
    <script src="libs/drawing_utils.js"></script>
    <script src="libs/pose.js"></script>
    ```
-5. En `app.js` cambie la importación de Transformers a
+3. En `src/app.js` cambie la importación de Transformers a
    ```javascript
    import { pipeline } from './libs/transformers.min.js';
    ```
    y actualice las opciones `locateFile` de MediaPipe para que devuelvan
    `'libs/' + f`.
-6. Reserve alrededor de **80 MB** de espacio libre para los modelos y
+4. Reserve alrededor de **80 MB** de espacio libre para los modelos y
    asegúrese de que los archivos se sirvan también mediante **HTTPS**.
 
 ## Recommended Browsers

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -9,6 +9,14 @@ beforeAll(() => {
   const settingsBtn = document.getElementById('settingsBtn');
   settingsBtn.addEventListener('click', () => settingsScreen.classList.add('show'));
 
+  const themeToggle = document.getElementById('themeToggle');
+  const themeValue = document.getElementById('themeValue');
+  themeToggle.addEventListener('click', () => {
+    const isLight = document.body.classList.toggle('light');
+    themeValue.textContent = isLight ? 'Light' : 'Dark';
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
+  });
+
   const micBtn = document.getElementById('micBtn');
   global.micCalls = 0;
   micBtn.addEventListener('click', () => {
@@ -48,5 +56,14 @@ describe('index.html', () => {
     micBtn.click();
     expect(micBtn.classList.contains('active')).toBe(false);
     expect(global.micCalls).toBe(4);
+  });
+
+  test('theme toggle saves preference', () => {
+    const toggle = document.getElementById('themeToggle');
+    localStorage.clear();
+    toggle.click();
+    expect(localStorage.getItem('theme')).toBe('light');
+    toggle.click();
+    expect(localStorage.getItem('theme')).toBe('dark');
   });
 });

--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
   </div>
 
 
-  <script src="app.js" type="module" defer></script>
+  <script src="src/app.js" type="module" defer></script>
   <!-- Whisper tiny (q8) local + Tracker Combinado -->
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "se-ar2",
   "version": "1.0.0",
   "description": "A minimal prototype (MVP) of the SeñAR app. This single page web application provides sign language recognition features and audio transcription directly in the browser.",
-  "main": "app.js",
+  "main": "src/app.js",
   "scripts": {
     "test": "jest",
     "start": "npx http-server . -p 8000",
-    "lint": "eslint -c .eslintrc.cjs app.js __tests__/index.test.js"
+    "lint": "eslint -c .eslintrc.cjs src/app.js __tests__/index.test.js",
+    "prepare-offline": "node scripts/prepareOffline.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/prepareOffline.js
+++ b/scripts/prepareOffline.js
@@ -1,0 +1,42 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const files = {
+  'hands.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js',
+  'face_mesh.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js',
+  'drawing_utils.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js',
+  'pose.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose.js',
+  'transformers.min.js': 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2/dist/transformers.min.js'
+};
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https.get(url, response => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`Request Failed. Status Code: ${response.statusCode}`));
+        return;
+      }
+      response.pipe(file);
+      file.on('finish', () => file.close(resolve));
+    }).on('error', err => {
+      fs.unlink(dest, () => reject(err));
+    });
+  });
+}
+
+(async () => {
+  const dir = path.join(__dirname, '..', 'libs');
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [name, url] of Object.entries(files)) {
+    const dest = path.join(dir, name);
+    console.log(`Downloading ${name}...`);
+    try {
+      await download(url, dest);
+      console.log(`Saved ${dest}`);
+    } catch (err) {
+      console.error(`Failed to download ${url}:`, err.message);
+    }
+  }
+})();

--- a/src/app.js
+++ b/src/app.js
@@ -26,6 +26,20 @@
 const accent = rootStyles.getPropertyValue('--accent').trim() || '#2EB8A3';
 const accentRGB = rootStyles.getPropertyValue('--accent-rgb').trim() || '46,184,163';
 
+    // Load saved settings
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light') {
+      document.body.classList.add('light');
+      themeValue.textContent = 'Light';
+    }
+
+    const savedSize = localStorage.getItem('subtitleSize');
+    if (savedSize) {
+      subtitleSizeSlider.value = savedSize;
+      subtitleSizeValue.textContent = savedSize + ' pt';
+      captionContainer.style.fontSize = savedSize + 'px';
+    }
+
     function drawMarker(ctx,x,y,r){
       const g=ctx.createRadialGradient(x,y,0,x,y,r);
       g.addColorStop(0,`rgba(${accentRGB},0.8)`);
@@ -54,7 +68,7 @@ const accentRGB = rootStyles.getPropertyValue('--accent-rgb').trim() || '46,184,
         video.srcObject=s;
         fallbackCam.classList.remove("show");
       }catch(e){
-        fallbackCam.textContent = `\ud83d\udcf7 ${e.message}`;
+        fallbackCam.textContent = `\ud83d\udcf7 ${e.message}. Permite el acceso a la cámara y recarga la página.`;
         fallbackCam.classList.add("show");
       }
     }
@@ -112,10 +126,19 @@ Promise.all(tasks).then(() => {
     settingsBack.onclick=e=>{ripple(e,settingsBack);settingsScreen.classList.remove('show');};
 
     /* ---------- Theme ---------- */
-    themeToggle.onclick=e=>{ripple(e,themeToggle);document.body.classList.toggle('light');themeValue.textContent=document.body.classList.contains('light')?'Light':'Dark';};
+    themeToggle.onclick=e=>{
+      ripple(e,themeToggle);
+      const isLight = document.body.classList.toggle('light');
+      themeValue.textContent = isLight ? 'Light' : 'Dark';
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    };
 
     /* ---------- Subtitle size ---------- */
-    subtitleSizeSlider.oninput=()=>{subtitleSizeValue.textContent=subtitleSizeSlider.value+' pt';captionContainer.style.fontSize=subtitleSizeSlider.value+'px';};
+    subtitleSizeSlider.oninput=()=>{
+      subtitleSizeValue.textContent = subtitleSizeSlider.value + ' pt';
+      captionContainer.style.fontSize = subtitleSizeSlider.value + 'px';
+      localStorage.setItem('subtitleSize', subtitleSizeSlider.value);
+    };
 
     /* ---------- Mic ---------- */
     let recog;
@@ -224,7 +247,10 @@ Promise.all(tasks).then(() => {
     requestAnimationFrame(fps);
 
     /* ---------- Fallback speech ---------- */
-    if(!SR)fallbackSpeech.classList.add('show');
+    if(!SR){
+      fallbackSpeech.textContent = '\ud83c\udf99\ufe0f Voz no soportada. Usa un navegador compatible.';
+      fallbackSpeech.classList.add('show');
+    }
 
     /* ========================================================================
        Drag & Drop subtítulos (+ microinteracciones) 
@@ -329,7 +355,7 @@ const transcriberP = pipeline('automatic-speech-recognition', 'Xenova/whisper-ti
             captionText.textContent='Grabando…';progress.style.width='15%';
           }else{recorder.stop();}
         }catch(err){
-          fallbackSpeech.textContent = `\ud83c\udf99\ufe0f ${err.message}`;
+          fallbackSpeech.textContent = `\ud83c\udf99\ufe0f ${err.message}. Verifique los permisos de micrófono.`;
           fallbackSpeech.classList.add('show');
         }
       })();


### PR DESCRIPTION
## Summary
- restructure project to use `src/app.js`
- add `prepare-offline` script to download models
- persist theme and subtitle size in localStorage
- display clearer camera/microphone error messages
- update README with offline script instructions
- update tests for theme persistence

## Testing
- `npm run lint`
- `npm test`
- `node scripts/prepareOffline.js` *(fails: blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_68533ef9275083319856d07c6e19bc71