### PR TITLE
Add dialect selector and offline progress features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Thumbs.db
 *.tmp
 *~
 
+libs/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ estáticos a través de un servidor local como se muestra arriba.
 Para ejecutar la demo sin conexión:
 
 1. Ejecute `npm run prepare-offline` para descargar los modelos y crear
-   la carpeta `libs/` automáticamente.
+   la carpeta `libs/` automáticamente. El script genera un archivo
+   `libs/progress.json` que actualiza el avance de cada descarga y
+   puede consultarse desde la interfaz.
 2. Modifique las etiquetas `<script>` de `index.html` para que apunten a los
    archivos locales, por ejemplo:
    ```html
@@ -91,6 +93,13 @@ Para ejecutar la demo sin conexión:
    `'libs/' + f`.
 4. Reserve alrededor de **80 MB** de espacio libre para los modelos y
    asegúrese de que los archivos se sirvan también mediante **HTTPS**.
+
+### Dialects
+
+Desde la pantalla de configuraciones ahora es posible elegir el dialecto de
+LSA a utilizar. Las opciones iniciales son **Noroeste**, **Cuyo** y
+**Noreste**. La selección se guarda en `localStorage` y se aplica al iniciar
+la aplicación.
 
 ## Recommended Browsers
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -17,6 +17,11 @@ beforeAll(() => {
     localStorage.setItem('theme', isLight ? 'light' : 'dark');
   });
 
+  const dialectSelect = document.getElementById('dialectSelect');
+  dialectSelect.addEventListener('change', () => {
+    localStorage.setItem('dialect', dialectSelect.value);
+  });
+
   const micBtn = document.getElementById('micBtn');
   global.micCalls = 0;
   micBtn.addEventListener('click', () => {
@@ -65,5 +70,13 @@ describe('index.html', () => {
     expect(localStorage.getItem('theme')).toBe('light');
     toggle.click();
     expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  test('dialect select saves preference', () => {
+    const select = document.getElementById('dialectSelect');
+    localStorage.clear();
+    select.value = 'cuyo';
+    select.dispatchEvent(new Event('change'));
+    expect(localStorage.getItem('dialect')).toBe('cuyo');
   });
 });

--- a/__tests__/offline.test.js
+++ b/__tests__/offline.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const libsDir = path.resolve(__dirname, '../libs');
+
+beforeAll(() => {
+  if (fs.existsSync(libsDir)) fs.rmSync(libsDir, { recursive: true, force: true });
+});
+
+test('prepareOffline creates progress file in dry run', async () => {
+  process.env.DRY_RUN = '1';
+  await require('../scripts/prepareOffline.js')();
+  const progressFile = path.join(libsDir, 'progress.json');
+  expect(fs.existsSync(progressFile)).toBe(true);
+  const data = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
+  expect(data['hands.js']).toBeDefined();
+});

--- a/index.html
+++ b/index.html
@@ -255,7 +255,16 @@
       <div class="settings-section">
         <div class="group-title">Dialects</div>
         <div class="settings-card">
-          <div class="settings-item"><div class="item-icon">🇦🇷</div><div class="item-label">Northeast</div><div class="badge">New</div></div>
+          <div class="settings-item">
+            <div class="item-label">Dialect</div>
+            <div class="item-control">
+              <select id="dialectSelect">
+                <option value="noroeste">Noroeste</option>
+                <option value="cuyo">Cuyo</option>
+                <option value="noreste">Noreste</option>
+              </select>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/scripts/prepareOffline.js
+++ b/scripts/prepareOffline.js
@@ -10,7 +10,7 @@ const files = {
   'transformers.min.js': 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2/dist/transformers.min.js'
 };
 
-function download(url, dest) {
+function download(url, dest, onProgress) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
     https.get(url, response => {
@@ -18,6 +18,12 @@ function download(url, dest) {
         reject(new Error(`Request Failed. Status Code: ${response.statusCode}`));
         return;
       }
+      const total = parseInt(response.headers['content-length'], 10) || 0;
+      let downloaded = 0;
+      response.on('data', chunk => {
+        downloaded += chunk.length;
+        onProgress(downloaded, total);
+      });
       response.pipe(file);
       file.on('finish', () => file.close(resolve));
     }).on('error', err => {
@@ -26,17 +32,43 @@ function download(url, dest) {
   });
 }
 
-(async () => {
+async function main() {
   const dir = path.join(__dirname, '..', 'libs');
   fs.mkdirSync(dir, { recursive: true });
+  const progressPath = path.join(dir, 'progress.json');
+  const progress = {};
+  const writeProgress = () => {
+    fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
+  };
   for (const [name, url] of Object.entries(files)) {
     const dest = path.join(dir, name);
+    progress[name] = { downloaded: 0, total: 0 };
+    writeProgress();
+    if (process.env.DRY_RUN === '1') {
+      progress[name] = { downloaded: 1, total: 1 };
+      writeProgress();
+      console.log(`Saved ${dest}`);
+      continue;
+    }
     console.log(`Downloading ${name}...`);
     try {
-      await download(url, dest);
-      console.log(`Saved ${dest}`);
+      await download(url, dest, (dl, total) => {
+        progress[name] = { downloaded: dl, total };
+        writeProgress();
+        if (total) {
+          const pct = ((dl / total) * 100).toFixed(0);
+          process.stdout.write(`\r${name}: ${pct}%   `);
+        }
+      });
+      console.log(`\nSaved ${dest}`);
     } catch (err) {
       console.error(`Failed to download ${url}:`, err.message);
     }
   }
-})();
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = main;

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@
     const themeValue = document.getElementById('themeValue');
     const subtitleSizeSlider = document.getElementById('subtitleSizeSlider');
     const subtitleSizeValue = document.getElementById('subtitleSizeValue');
+    const dialectSelect = document.getElementById('dialectSelect');
     const video = document.getElementById('video');
     const fallbackCam = document.getElementById('fallbackCam');
     const fallbackSpeech = document.getElementById('fallbackSpeech');
@@ -38,6 +39,11 @@ const accentRGB = rootStyles.getPropertyValue('--accent-rgb').trim() || '46,184,
       subtitleSizeSlider.value = savedSize;
       subtitleSizeValue.textContent = savedSize + ' pt';
       captionContainer.style.fontSize = savedSize + 'px';
+    }
+
+    const savedDialect = localStorage.getItem('dialect');
+    if (savedDialect && dialectSelect) {
+      dialectSelect.value = savedDialect;
     }
 
     function drawMarker(ctx,x,y,r){
@@ -139,6 +145,12 @@ Promise.all(tasks).then(() => {
       captionContainer.style.fontSize = subtitleSizeSlider.value + 'px';
       localStorage.setItem('subtitleSize', subtitleSizeSlider.value);
     };
+
+    if (dialectSelect) {
+      dialectSelect.onchange = () => {
+        localStorage.setItem('dialect', dialectSelect.value);
+      };
+    }
 
     /* ---------- Mic ---------- */
     let recog;

--- a/styles.css
+++ b/styles.css
@@ -293,6 +293,11 @@
     .item-sub { font-size: 13px; color: #8e8e93; }
     .item-value { font-size: 17px; color: #8e8e93; }
     .item-control { display: flex; align-items: center; gap: 8px; }
+    .item-control select {
+      font-size: 15px;
+      padding: 4px 8px;
+      border-radius: 8px;
+    }
     .settings-button.primary { background: #007aff; color: #fff; border: none; padding: 6px 12px; border-radius: 14px; font-size: 15px; }
     .settings-button.secondary { background: #f2f2f7; color: #000; border: none; padding: 6px 12px; border-radius: 14px; font-size: 15px; }
     .badge { background: #f2f2f7; color: #8e8e93; padding: 2px 8px; border-radius: 12px; font-size: 13px; }
@@ -325,6 +330,14 @@
       .controls-left button {
         width: 40px;
         height: 40px;
+      }
+
+      .settings-content {
+        padding: var(--spacing);
+      }
+
+      .settings-item {
+        padding: 12px;
       }
 
       .caption-container {


### PR DESCRIPTION
## Summary
- ignore generated `libs` directory
- add progress reporting to `prepareOffline.js`
- allow selection of dialect from settings
- improve responsive styling
- update docs for offline downloads and dialect menu
- test offline script and dialect persistence

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853460c4408833199f98ee7a98658e6