### PR TITLE
Add unit tests for static sign detection

### DIFF
--- a/__tests__/staticSigns.test.js
+++ b/__tests__/staticSigns.test.js
@@ -1,0 +1,50 @@
+const requireEsm = require('esm')(module);
+const { detectStaticSign } = requireEsm('../src/staticSigns.js');
+
+function baseHand() {
+  const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+  lm[3].x = 0; lm[4].x = 1; // thumb not extended
+  lm[6].y = 0; lm[8].y = 1; // index not extended
+  lm[10].y = 0; lm[12].y = 1; // middle not extended
+  lm[14].y = 0; lm[16].y = 1; // ring not extended
+  lm[18].y = 0; lm[20].y = 1; // pinky not extended
+  return lm;
+}
+
+describe('detectStaticSign', () => {
+  test('detects sign A', () => {
+    const lm = baseHand();
+    lm[4].x = -1; // thumb extended
+    expect(detectStaticSign(lm)).toBe('A');
+  });
+
+  test('detects sign B', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[12].y = -1; lm[16].y = -1; lm[20].y = -1; // fingers extended
+    expect(detectStaticSign(lm)).toBe('B');
+  });
+
+  test('detects sign C', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[12].y = -1; // index and middle extended
+    expect(detectStaticSign(lm)).toBe('C');
+  });
+
+  test('detects sign D', () => {
+    const lm = baseHand();
+    lm[8].y = -1; // only index extended
+    expect(detectStaticSign(lm)).toBe('D');
+  });
+
+  test('detects sign E', () => {
+    const lm = baseHand();
+    expect(detectStaticSign(lm)).toBe('E');
+  });
+
+  test('returns null for malformed input', () => {
+    expect(detectStaticSign(null)).toBeNull();
+    expect(detectStaticSign([])).toBeNull();
+    const shortArray = Array.from({ length: 10 }, () => ({ x: 0, y: 0 }));
+    expect(detectStaticSign(shortArray)).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "eslint": "^8.57.1",
+        "esm": "^3.2.25",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0"
       }
@@ -2959,6 +2960,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint": "^8.57.1",
+    "esm": "^3.2.25",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0"
   },

--- a/src/staticSigns.js
+++ b/src/staticSigns.js
@@ -14,3 +14,8 @@ export function detectStaticSign(lm) {
   if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt) return 'E';
   return null;
 }
+
+// Support CommonJS for tests
+if (typeof module !== 'undefined') {
+  module.exports = { detectStaticSign };
+}


### PR DESCRIPTION
## Summary
- add Jest tests for detectStaticSign to check recognition of signs A–E
- enable commonjs export of detectStaticSign for tests
- install `esm` for loading ES modules in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685350638b48833193c66528fac825ce