### PR TITLE
Switch to local libs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,24 +90,11 @@ Para ejecutar la demo sin conexión:
    }
    ```
 
-   Para realizar pruebas sin conectar a Internet utilice `DRY_RUN=1 npm run prepare-offline`,
-   lo que genera entradas de progreso sin realizar descargas reales.
-2. Modifique las etiquetas `<script>` de `index.html` para que apunten a los
-   archivos locales, por ejemplo:
-   ```html
-   <script src="libs/hands.js"></script>
-   <script src="libs/face_mesh.js"></script>
-   <script src="libs/drawing_utils.js"></script>
-   <script src="libs/pose.js"></script>
-   ```
-3. En `src/app.js` cambie la importación de Transformers a
-   ```javascript
-   import { pipeline } from './libs/transformers.min.js';
-   ```
-   y actualice las opciones `locateFile` de MediaPipe para que devuelvan
-   `'libs/' + f`.
-  4. Reserve alrededor de **80 MB** de espacio libre para los modelos y
-     asegúrese de que los archivos se sirvan también mediante **HTTPS**.
+2. Si solo desea verificar el proceso sin descargar los archivos reales,
+  ejecute `DRY_RUN=1 npm run prepare-offline`, lo que genera las entradas de
+  `progress.json` sin realizar descargas.
+3. Reserve alrededor de **80 MB** de espacio libre para los modelos y asegúrese
+   de que los archivos se sirvan también mediante **HTTPS**.
 
 Dentro de la pantalla de configuraciones se incluye un botón para descargar el
 modelo de transcripción de audio directamente al caché del navegador. El

--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="styles.css">
 
   <!-- MediaPipe libraries for Tracker Combinado -->
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose.js"></script>
+  <script src="libs/hands.js"></script>
+  <script src="libs/face_mesh.js"></script>
+  <script src="libs/drawing_utils.js"></script>
+  <script src="libs/pose.js"></script>
 </head>
 <body>
   <!-- Splash Screen -->

--- a/src/app.js
+++ b/src/app.js
@@ -494,7 +494,7 @@ Promise.all(tasks).then(() => {
         captionContainer.classList.remove('drop');
       });
     })();
-import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2/dist/transformers.min.js';
+import { pipeline } from './libs/transformers.min.js';
 const device = navigator.gpu ? 'webgpu' : 'wasm';
 const transcriberP = pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny', { quantized: true, device });
 // Reuse existing element references defined at the top of the file
@@ -545,11 +545,11 @@ const transcriberP = pipeline('automatic-speech-recognition', 'Xenova/whisper-ti
     /* Tracker Combinado */
     const canvasTracker=document.getElementById('trackerCanvas')||(()=>{const c=document.createElement('canvas');c.id='trackerCanvas';video.parentNode.insertBefore(c,video.nextSibling);return c;})();
     const ctxTracker=canvasTracker.getContext('2d',{willReadFrequently:true});
-    const hands=new Hands({locateFile:f=>`https://cdn.jsdelivr.net/npm/@mediapipe/hands/${f}`});
+    const hands=new Hands({locateFile:f=>`libs/${f}`});
     hands.setOptions({maxNumHands:2,modelComplexity:1,minDetectionConfidence:0.7,minTrackingConfidence:0.7});
-    const faceMesh=new FaceMesh({locateFile:f=>`https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/${f}`});
+    const faceMesh=new FaceMesh({locateFile:f=>`libs/${f}`});
     faceMesh.setOptions({maxNumFaces:1,refineLandmarks:true,minDetectionConfidence:0.7,minTrackingConfidence:0.7});
-    const pose=new Pose({locateFile:f=>`https://cdn.jsdelivr.net/npm/@mediapipe/pose/${f}`});
+    const pose=new Pose({locateFile:f=>`libs/${f}`});
     pose.setOptions({modelComplexity:1,enableSegmentation:false,minDetectionConfidence:0.7,minTrackingConfidence:0.7});
     let handLandmarks=[],faceLandmarks=null,poseLandmarks=null;
     hands.onResults(r=>handLandmarks=r.multiHandLandmarks||[]);

--- a/sw.js
+++ b/sw.js
@@ -6,11 +6,12 @@ const ASSETS = [
   '/src/app.js',
   '/src/sw-register.js',
   '/three.min.js',
-  '/drawing_utils.js',
-  '/face_mesh.js',
-  '/hands.js',
-  '/pose.js',
   '/opencv.js',
+  '/libs/drawing_utils.js',
+  '/libs/face_mesh.js',
+  '/libs/hands.js',
+  '/libs/pose.js',
+  '/libs/transformers.min.js',
 ];
 self.addEventListener('install', evt => {
   self.skipWaiting();


### PR DESCRIPTION
## Summary
- use MediaPipe libraries from `libs/`
- import Transformers locally
- cache these libraries in the service worker
- update README offline instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685356d7fb448331a4330f64c9e44fd0