### PR TITLE
Add camera switch step to tour

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -175,7 +175,15 @@ Promise.all(tasks).then(() => {
 
 
     /* ---------- Guided tour ---------- */
-    const steps=[{el:'#settingsBtn',text:'Accede a configuraciones.'},{el:'#themeToggle',text:'Cambia tema.'},{el:'#pauseBtn',text:'Pausa/reanuda.'},{el:'#snapshotBtn',text:'Captura pantalla.'},{el:'#restartBtn',text:'Reinicia.'},{el:'#micBtn',text:'Activa voz.'}];
+    const steps=[
+      {el:'#settingsBtn',text:'Accede a configuraciones.'},
+      {el:'#themeToggle',text:'Cambia tema.'},
+      {el:'#pauseBtn',text:'Pausa/reanuda.'},
+      {el:'#snapshotBtn',text:'Captura pantalla.'},
+      {el:'#switchCamBtn',text:'Cambia cámara.'},
+      {el:'#restartBtn',text:'Reinicia.'},
+      {el:'#micBtn',text:'Activa voz.'}
+    ];
     let idx=0;
     function startTour(){tourOverlay.classList.add('active');show(idx);}
     function show(i){const t=steps[i],e=document.querySelector(t.el),r=e.getBoundingClientRect();tourTooltip.textContent=t.text;tourTooltip.style.top=`${r.bottom+10}px`;tourTooltip.style.left=`${r.left}px`;}    


### PR DESCRIPTION
## Summary
- showcase camera switching by adding the `switchCamBtn` step

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68537ebcad288331a38c3909a60af9a7