### PR TITLE
Add ripple listener to splash

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -200,7 +200,7 @@ Promise.all(tasks).then(() => {
     function endTour(){if(highlightEl)highlightEl.classList.remove('tour-highlight');tourOverlay.classList.remove('active');localStorage.setItem('tourSeen','true');}
 
     /* ---------- Helper ripple ---------- */
-    function ripple(e,el){const r=el.getBoundingClientRect(),s=Math.max(r.width,r.height);let x=e&&e.clientX,y=e&&e.clientY;if(!x&&!y){x=r.left+r.width/2;y=r.top+r.height/2;}x-=r.left+s/2;y-=r.top+s/2;const sp=document.createElement('span');sp.className='ripple';sp.style.width=sp.style.height=s+'px';sp.style.left=x+'px';sp.style.top=y+'px';el.appendChild(sp);sp.onanimationend=()=>sp.remove();}
+    export function ripple(e,el){const r=el.getBoundingClientRect(),s=Math.max(r.width,r.height);let x=e&&e.clientX,y=e&&e.clientY;if(!x&&!y){x=r.left+r.width/2;y=r.top+r.height/2;}x-=r.left+s/2;y-=r.top+s/2;const sp=document.createElement('span');sp.className='ripple';sp.style.width=sp.style.height=s+'px';sp.style.left=x+'px';sp.style.top=y+'px';el.appendChild(sp);sp.onanimationend=()=>sp.remove();}
 
     function vibrate(pattern){
       if(hapticsEnabled && navigator.vibrate) navigator.vibrate(pattern);

--- a/src/splash.js
+++ b/src/splash.js
@@ -1,7 +1,13 @@
 export let updateProgress = () => {};
+import { ripple } from './app.js';
 export function initSplash(canvas) {
   const ctx = canvas.getContext('2d');
   const dpr = window.devicePixelRatio || 1;
+
+  function onPointerDown(evt) {
+    ripple(evt, canvas);
+  }
+  canvas.addEventListener('pointerdown', onPointerDown);
 
   const WIDTH = () => window.innerWidth;
   const HEIGHT = () => window.innerHeight;
@@ -152,6 +158,7 @@ export function initSplash(canvas) {
       splashOpacity = Math.max(0, 1 - (fadeElapsed / FADE_OUT_MS));
       if (splashOpacity <= 0) {
         canvas.style.display = 'none';
+        canvas.removeEventListener('pointerdown', onPointerDown);
         window.dispatchEvent(new Event('splashDone'));
         return;
       }


### PR DESCRIPTION
## Summary
- export `ripple` helper from app module
- use `ripple` on splash screen pointer events and remove listener when splash hides

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538d81875c833181da133b1db4d5d8