### PR TITLE
Add loading pulse to splash wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
 <body>
   <!-- Splash Screen -->
 
-  <canvas id="splash"></canvas>
+  <div id="splashWrapper">
+    <canvas id="splash"></canvas>
+  </div>
   <audio id="enter-sound" src="enter.mp3" preload="auto"></audio>
   <audio id="done-sound" src="done.mp3" preload="auto"></audio>
   <script type="module">

--- a/src/splash.js
+++ b/src/splash.js
@@ -1,6 +1,8 @@
 export let updateProgress = () => {};
 import { ripple } from './app.js';
 export function initSplash(canvas) {
+  const wrapper = canvas.parentElement;
+  if (wrapper) wrapper.classList.add('loading');
   const ctx = canvas.getContext('2d');
   const dpr = window.devicePixelRatio || 1;
 
@@ -44,6 +46,10 @@ export function initSplash(canvas) {
 
   updateProgress = function(pct, text = '') {
     loaderProgress = Math.max(0, Math.min(1, pct));
+    if (wrapper) {
+      if (loaderProgress < 1) wrapper.classList.add('loading');
+      else wrapper.classList.remove('loading');
+    }
     if (text) statusText = text;
     if (loaderProgress >= 1 && !fadeOutStart) {
       fadeOutStart = performance.now();

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,9 @@ body.light {
       background: #F9F9FC;
       z-index: 1000;
     }
+    #splashWrapper.loading {
+      animation: pulse 1.5s infinite;
+    }
     /* Guided Tour */
     .tour-overlay {
       position: absolute;


### PR DESCRIPTION
## Summary
- wrap the splash canvas in a new `#splashWrapper` element
- animate the wrapper with `pulse` while loading
- control the wrapper's `loading` class from `splash.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_68538eb0bacc8331bff67963f7fc90a1