### PR TITLE
Add snapshot flash animation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -406,6 +406,10 @@ Promise.all(tasks).then(() => {
       l.href=c.toDataURL();
       l.download='snapshot.png';
       l.click();
+      document.body.classList.add('snapshot-flash');
+      document.body.addEventListener('animationend',()=>{
+        document.body.classList.remove('snapshot-flash');
+      },{once:true});
     });
     restartBtn.addEventListener('click',()=>location.reload());
     switchCamBtn.addEventListener('click',async e=>{

--- a/styles.css
+++ b/styles.css
@@ -291,11 +291,25 @@ body.light {
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb),0.6);} 70% { box-shadow: 0 0 0 20px rgba(var(--accent-rgb),0);} 100% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb),0);} }
     @keyframes startup { from { transform: rotate(-15deg); } to { transform: rotate(0deg); } }
-    @keyframes dropBounce {
+@keyframes dropBounce {
       0% { transform: scale(1.05); }
       40% { transform: scale(0.95); }
       60% { transform: scale(1.02); }
       100% { transform: scale(1); }
+    }
+    /* Snapshot flash animation */
+    body.snapshot-flash::after {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: #fff;
+      pointer-events: none;
+      animation: flash 0.4s ease-out forwards;
+      z-index: 3000;
+    }
+    @keyframes flash {
+      from { opacity: 0.8; }
+      to { opacity: 0; }
     }
     /* Settings Screen */
     .settings-screen {


### PR DESCRIPTION
## Summary
- trigger a flash animation when taking a snapshot
- style the temporary flash overlay with CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685392e4f5688331b611ce8db1fe8891