### PR TITLE
Handle both hands in sign detection

### DIFF
--- a/src/handUtils.js
+++ b/src/handUtils.js
@@ -1,0 +1,17 @@
+import { detectStaticSign } from './staticSigns.js';
+
+export function formatSigns(lms = [], handsInfo = []) {
+  const parts = [];
+  for (let i = 0; i < lms.length; i++) {
+    const sign = detectStaticSign(lms[i]);
+    if (!sign) continue;
+    const label = handsInfo[i] && handsInfo[i].label ? handsInfo[i].label : `Hand ${i + 1}`;
+    parts.push(`${label}: ${sign}`);
+  }
+  return parts.join(' / ');
+}
+
+// Support CommonJS for tests
+if (typeof module !== 'undefined') {
+  module.exports = { formatSigns };
+}


### PR DESCRIPTION
## Summary
- add `handUtils` helper with `formatSigns`
- capture handedness results and show both hands
- test `formatSigns` via `index.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853952ea6548331887cccd778465c7c