### PR TITLE
Add signs F–J detection and tests

### DIFF
--- a/__tests__/staticSigns.test.js
+++ b/__tests__/staticSigns.test.js
@@ -41,6 +41,41 @@ describe('detectStaticSign', () => {
     expect(detectStaticSign(lm)).toBe('E');
   });
 
+  test('detects sign F', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[4].y = -1; // thumb extended
+    lm[8].x = -1; lm[8].y = -1; // index extended touching thumb
+    lm[12].y = -1; lm[16].y = -1; lm[20].y = -1; // other fingers extended
+    expect(detectStaticSign(lm)).toBe('F');
+  });
+
+  test('detects sign G', () => {
+    const lm = baseHand();
+    lm[4].x = -1; // thumb extended
+    lm[8].y = -1; // index extended
+    expect(detectStaticSign(lm)).toBe('G');
+  });
+
+  test('detects sign H', () => {
+    const lm = baseHand();
+    lm[4].x = -1; // thumb extended
+    lm[8].y = -1; lm[12].y = -1; // index and middle extended
+    expect(detectStaticSign(lm)).toBe('H');
+  });
+
+  test('detects sign I', () => {
+    const lm = baseHand();
+    lm[20].y = -1; // pinky extended
+    expect(detectStaticSign(lm)).toBe('I');
+  });
+
+  test('detects sign J', () => {
+    const lm = baseHand();
+    lm[4].x = -1; // thumb extended
+    lm[20].y = -1; // pinky extended
+    expect(detectStaticSign(lm)).toBe('J');
+  });
+
   test('returns null for malformed input', () => {
     expect(detectStaticSign(null)).toBeNull();
     expect(detectStaticSign([])).toBeNull();

--- a/src/handUtils.js
+++ b/src/handUtils.js
@@ -1,12 +1,14 @@
 import { detectStaticSign } from './staticSigns.js';
 
 export function formatSigns(lms = [], handsInfo = []) {
+  const numberMap = { F: 6, G: 7, H: 8, I: 9, J: 10 };
   const parts = [];
   for (let i = 0; i < lms.length; i++) {
     const sign = detectStaticSign(lms[i]);
     if (!sign) continue;
     const label = handsInfo[i] && handsInfo[i].label ? handsInfo[i].label : `Hand ${i + 1}`;
-    parts.push(`${label}: ${sign}`);
+    const out = numberMap[sign] ? String(numberMap[sign]) : sign;
+    parts.push(`${label}: ${out}`);
   }
   return parts.join(' / ');
 }

--- a/src/staticSigns.js
+++ b/src/staticSigns.js
@@ -1,11 +1,22 @@
 export function detectStaticSign(lm) {
   if (!lm || lm.length < 21) return null;
   const ext = i => lm[i].y < lm[i - 2].y;
+  const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
   const thumbExt = lm[4].x < lm[3].x;
   const indexExt = ext(8);
   const middleExt = ext(12);
   const ringExt = ext(16);
   const pinkExt = ext(20);
+
+  // New letters F-J
+  if (indexExt && middleExt && ringExt && pinkExt && thumbExt &&
+      dist(lm[4], lm[8]) < 0.1) return 'F';
+  if (indexExt && thumbExt && !middleExt && !ringExt && !pinkExt) return 'G';
+  if (indexExt && middleExt && thumbExt && !ringExt && !pinkExt) return 'H';
+  if (!indexExt && !middleExt && !ringExt && pinkExt && !thumbExt) return 'I';
+  // J is normally dynamic, tracing a curve with the pinky. We assume the final
+  // pose where the pinky and thumb are extended.
+  if (!indexExt && !middleExt && !ringExt && pinkExt && thumbExt) return 'J';
 
   if (!indexExt && !middleExt && !ringExt && !pinkExt && thumbExt) return 'A';
   if (indexExt && middleExt && ringExt && pinkExt && !thumbExt) return 'B';


### PR DESCRIPTION
## Summary
- expand static sign recognition with signs F–J
- map recognised F–J to numbers when formatting
- test new sign heuristics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539b2e37d48331952e9b67644a8f3c