### PR TITLE
Add update prompt tests and F-J sign detection

### DIFF
--- a/__tests__/staticSigns.test.js
+++ b/__tests__/staticSigns.test.js
@@ -82,4 +82,37 @@ describe('detectStaticSign', () => {
     const shortArray = Array.from({ length: 10 }, () => ({ x: 0, y: 0 }));
     expect(detectStaticSign(shortArray)).toBeNull();
   });
+
+  // Additional tests for F-J using mocked landmark arrays
+  test('recognizes sign F with separate array', () => {
+    const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+    lm[4] = { x: -1, y: -1 };
+    lm[8] = { x: -1, y: -1 };
+    lm[12].y = -1; lm[16].y = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('F');
+  });
+
+  test('recognizes sign G with separate array', () => {
+    const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+    lm[4].x = -1; lm[8].y = -1;
+    expect(detectStaticSign(lm)).toBe('G');
+  });
+
+  test('recognizes sign H with separate array', () => {
+    const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+    lm[4].x = -1; lm[8].y = -1; lm[12].y = -1;
+    expect(detectStaticSign(lm)).toBe('H');
+  });
+
+  test('recognizes sign I with separate array', () => {
+    const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+    lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('I');
+  });
+
+  test('recognizes sign J with separate array', () => {
+    const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+    lm[4].x = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('J');
+  });
 });

--- a/__tests__/sw.test.js
+++ b/__tests__/sw.test.js
@@ -1,16 +1,49 @@
-const path = require('path');
-
 beforeEach(() => {
   jest.resetModules();
 });
 
 test('service worker registers', () => {
-  const register = jest.fn().mockResolvedValue({});
+  const register = jest.fn().mockResolvedValue({ addEventListener: jest.fn() });
   Object.defineProperty(window, 'navigator', {
-    value: { serviceWorker: { register } },
+    value: { serviceWorker: { register, addEventListener: jest.fn() } },
     configurable: true
   });
   require('../src/sw-register.js');
   window.dispatchEvent(new Event('load'));
   expect(register).toHaveBeenCalledWith('sw.js');
+});
+
+test('prompts when waiting worker present', async () => {
+  const postMessage = jest.fn();
+  const register = jest.fn().mockResolvedValue({ waiting: { postMessage }, addEventListener: jest.fn() });
+  Object.defineProperty(window, 'navigator', {
+    value: { serviceWorker: { register, addEventListener: jest.fn() } },
+    configurable: true
+  });
+  window.confirm = jest.fn().mockReturnValue(false);
+  require('../src/sw-register.js');
+  window.dispatchEvent(new Event('load'));
+  await Promise.resolve();
+  expect(window.confirm).toHaveBeenCalled();
+  expect(postMessage).not.toHaveBeenCalled();
+});
+
+test('user accepts update posts message and reloads', async () => {
+  const postMessage = jest.fn();
+  const register = jest.fn().mockResolvedValue({ waiting: { postMessage }, addEventListener: jest.fn() });
+  let controllerHandler;
+  const addEventListener = jest.fn((e, cb) => { if (e === 'controllerchange') controllerHandler = cb; });
+  Object.defineProperty(window, 'navigator', {
+    value: { serviceWorker: { register, addEventListener } },
+    configurable: true
+  });
+  const swReg = require('../src/sw-register.js');
+  const reloadSpy = jest.fn();
+  swReg.setPageReload(reloadSpy);
+  window.confirm = jest.fn().mockReturnValue(true);
+  window.dispatchEvent(new Event('load'));
+  await Promise.resolve();
+  expect(postMessage).toHaveBeenCalledWith('SKIP_WAITING');
+  controllerHandler();
+  expect(reloadSpy).toHaveBeenCalled();
 });

--- a/src/sw-register.js
+++ b/src/sw-register.js
@@ -1,11 +1,42 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('sw.js').then(reg => {
+      const promptUpdate = worker => {
+        if (window.confirm('Update available. Reload?')) {
+          worker.postMessage('SKIP_WAITING');
+        }
+      };
+
       if (reg.waiting) {
-        console.log('Update ready');
+        promptUpdate(reg.waiting);
       }
+
+      reg.addEventListener('updatefound', () => {
+        const newWorker = reg.installing;
+        if (!newWorker) return;
+        newWorker.addEventListener('statechange', () => {
+          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+            promptUpdate(newWorker);
+          }
+        });
+      });
     }).catch(err => {
       console.error('SW registration failed', err);
     });
+
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      pageReload();
+    });
   });
+}
+
+let pageReload = () => {
+  window.location.reload();
+};
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    setPageReload(fn) { pageReload = fn; },
+    pageReload: () => pageReload(),
+  };
 }

--- a/sw.js
+++ b/sw.js
@@ -16,7 +16,6 @@ const ASSETS = [
   '/done.mp3',
 ];
 self.addEventListener('install', evt => {
-  self.skipWaiting();
   evt.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
   );
@@ -32,4 +31,8 @@ self.addEventListener('fetch', evt => {
   evt.respondWith(
     caches.match(evt.request).then(resp => resp || fetch(evt.request))
   );
+});
+
+self.addEventListener('message', evt => {
+  if (evt.data === 'SKIP_WAITING') self.skipWaiting();
 });


### PR DESCRIPTION
## Summary
- add user update prompt logic in service worker registration
- enable skipping waiting workers through posted message listener
- extend service worker tests for waiting worker and update flow
- add extra tests verifying static sign detection for F–J

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539ee300848331934a9b912eeafd13