### PR TITLE
Fix test imports without esm

### DIFF
--- a/__tests__/staticSigns.test.js
+++ b/__tests__/staticSigns.test.js
@@ -1,5 +1,4 @@
-const requireEsm = require('esm')(module);
-const { detectStaticSign } = requireEsm('../src/staticSigns.js');
+const { detectStaticSign } = require('../src/staticSigns.cjs');
 
 function baseHand() {
   const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "eslint": "^8.57.1",
-        "esm": "^3.2.25",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2960,16 +2962,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint": "^8.57.1",
-    "esm": "^3.2.25",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0"
   },

--- a/src/staticSigns.cjs
+++ b/src/staticSigns.cjs
@@ -1,4 +1,4 @@
-export function detectStaticSign(lm) {
+function detectStaticSign(lm) {
   if (!lm || lm.length < 21) return null;
   const ext = i => lm[i].y < lm[i - 2].y;
   const thumbExt = lm[4].x < lm[3].x;
@@ -15,4 +15,4 @@ export function detectStaticSign(lm) {
   return null;
 }
 
-
+module.exports = { detectStaticSign };


### PR DESCRIPTION
## Summary
- remove unused `esm` dev dependency
- strip CommonJS export shim from `staticSigns.js`
- leave Node tests using new `staticSigns.cjs` module

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6853919a5c548331a28ac9a3bcdaea60