### PR TITLE
Improve sign detection and stylize markers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "eslint": "^8.57.1",
+        "esm": "^3.2.25",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0"
       },
@@ -2962,6 +2963,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@testing-library/jest-dom": "^6.6.3",
     "eslint": "^8.57.1",
     "jest": "^30.0.0",
-    "jest-environment-jsdom": "^30.0.0"
+    "jest-environment-jsdom": "^30.0.0",
+    "esm": "^3.2.25"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,3 @@
-import { detectStaticSign } from './staticSigns.js';
 import { updateProgress } from './splash.js';
 import { formatSigns } from './handUtils.js';
 
@@ -90,11 +89,27 @@ let hapticsEnabled = true;
       }
 
     function drawMarker(ctx,x,y,r){
+      ctx.save();
+      ctx.lineWidth=2;
+      ctx.strokeStyle=accent;
+      ctx.beginPath();
+      ctx.arc(x,y,r,0,Math.PI*2);
+      ctx.stroke();
       const g=ctx.createRadialGradient(x,y,0,x,y,r);
-      g.addColorStop(0,`rgba(${accentRGB},0.8)`);
-      g.addColorStop(0.7,`rgba(${accentRGB},0.3)`);
+      g.addColorStop(0,`rgba(${accentRGB},0.9)`);
+      g.addColorStop(0.4,`rgba(${accentRGB},0.4)`);
       g.addColorStop(1,`rgba(${accentRGB},0)`);
-      ctx.fillStyle=g;ctx.beginPath();ctx.arc(x,y,r,0,Math.PI*2);ctx.fill();
+      ctx.fillStyle=g;
+      ctx.beginPath();
+      ctx.arc(x,y,r,0,Math.PI*2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(x-r*0.6,y);
+      ctx.lineTo(x+r*0.6,y);
+      ctx.moveTo(x,y-r*0.6);
+      ctx.lineTo(x,y+r*0.6);
+      ctx.stroke();
+      ctx.restore();
     }
     const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
     let camStream;

--- a/src/staticSigns.cjs
+++ b/src/staticSigns.cjs
@@ -1,11 +1,21 @@
 function detectStaticSign(lm) {
   if (!lm || lm.length < 21) return null;
   const ext = i => lm[i].y < lm[i - 2].y;
+  const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
   const thumbExt = lm[4].x < lm[3].x;
   const indexExt = ext(8);
   const middleExt = ext(12);
   const ringExt = ext(16);
   const pinkExt = ext(20);
+
+  // New letters F-J
+  if (indexExt && middleExt && ringExt && pinkExt && thumbExt &&
+      dist(lm[4], lm[8]) < 0.1) return 'F';
+  if (indexExt && thumbExt && !middleExt && !ringExt && !pinkExt) return 'G';
+  if (indexExt && middleExt && thumbExt && !ringExt && !pinkExt) return 'H';
+  if (!indexExt && !middleExt && !ringExt && pinkExt && !thumbExt) return 'I';
+  // J is normally dynamic; assume final pose with thumb and pinky extended
+  if (!indexExt && !middleExt && !ringExt && pinkExt && thumbExt) return 'J';
 
   if (!indexExt && !middleExt && !ringExt && !pinkExt && thumbExt) return 'A';
   if (indexExt && middleExt && ringExt && pinkExt && !thumbExt) return 'B';


### PR DESCRIPTION
## Summary
- show a sharper marker using gradient, ring and crosshair
- support extra signs F–J in CommonJS module
- install `esm` for tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a1e5bcbc8331b7cc5358b20c6ea2