### PR TITLE
Add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ transcription directly in the browser.
 * Herramientas para capturar imágenes y alternar cámaras durante la sesión.
 * Reconocimiento de señas estáticas **A–J** sin conexión.
 
+## Architecture
+
+The demo is organized as a single page web application. All scripts are loaded from **index.html** which boots `src/app.js` for gesture recognition and speech transcription. A service worker (`sw.js`) caches core assets so the page works as a PWA. Models downloaded via the settings screen or `npm run prepare-offline` are stored in the `offline-models` cache allowing the app to operate without a network connection.
+
+For a more detailed overview see [docs/architecture.md](docs/architecture.md).
+
 ## Prerequisites
 
 * **HTTPS hosting** – Media device APIs in modern browsers require a secure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+This document explains how the SeñAR demo is organized.
+
+## Components
+
+- **index.html** – Container for the entire UI and entry point for the modules.
+- **src/app.js** – Main logic that connects MediaPipe trackers, gesture
+  recognition and speech transcription.
+- **src/staticSigns.js** – Detects static letters of the alphabet for offline
+  sign recognition.
+- **sw.js** – Service worker caching core assets so the page works as a PWA.
+- **scripts/prepareOffline.js** – Node script that downloads the MediaPipe
+  libraries and stores a progress file to allow resumable downloads.
+
+## Offline model storage
+
+Models downloaded with `prepare-offline` or via the settings screen are saved in
+`libs/` and cached under the `offline-models` cache. The service worker loads
+these files from cache when available so the app can run without network
+connectivity.
+


### PR DESCRIPTION
## Summary
- document project architecture
- summarize design in README and link to docs

## Testing
- `npm test` *(fails: Cannot find module 'esm' and static sign tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6853a1b211fc83318252176034cd1830