### PR TITLE
Include wasm and data assets for offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ Para ejecutar la demo sin conexión:
   `progress.json` sin realizar descargas.
 3. Reserve alrededor de **80 MB** de espacio libre para los modelos y asegúrese
    de que los archivos se sirvan también mediante **HTTPS**.
+4. El script también descarga archivos `.wasm` y `.data` necesarios para las
+   soluciones de MediaPipe:
+   - `hands_solution_packed_assets.data` (~4&nbsp;MB)
+   - `hands_solution_wasm_bin.wasm` (~5.6&nbsp;MB)
+   - `hands_solution_simd_wasm_bin.wasm` (~5.7&nbsp;MB)
+   - `face_mesh_solution_packed_assets.data` (~3.8&nbsp;MB)
+   - `face_mesh_solution_wasm_bin.wasm` (~5.8&nbsp;MB)
+   - `face_mesh_solution_simd_wasm_bin.wasm` (~5.9&nbsp;MB)
+   - `pose_solution_packed_assets.data` (~2.8&nbsp;MB)
+   - `pose_solution_wasm_bin.wasm` (~5.7&nbsp;MB)
+   - `pose_solution_simd_wasm_bin.wasm` (~5.8&nbsp;MB)
 
 Dentro de la pantalla de configuraciones se incluye un botón para descargar el
 modelo de transcripción de audio directamente al caché del navegador. El

--- a/libs/progress.json
+++ b/libs/progress.json
@@ -23,12 +23,24 @@
     "downloaded": 8327,
     "total": 0
   },
+  "hands_solution_packed_assets.data": {
+    "downloaded": 0,
+    "total": 0
+  },
   "hands_solution_wasm_bin.js": {
     "downloaded": 276474,
     "total": 0
   },
   "hands_solution_simd_wasm_bin.js": {
     "downloaded": 276479,
+    "total": 0
+  },
+  "hands_solution_wasm_bin.wasm": {
+    "downloaded": 0,
+    "total": 0
+  },
+  "hands_solution_simd_wasm_bin.wasm": {
+    "downloaded": 0,
     "total": 0
   },
   "hand_landmark_full.tflite": {
@@ -47,12 +59,24 @@
     "downloaded": 8928,
     "total": 0
   },
+  "face_mesh_solution_packed_assets.data": {
+    "downloaded": 0,
+    "total": 0
+  },
   "face_mesh_solution_wasm_bin.js": {
     "downloaded": 330161,
     "total": 0
   },
   "face_mesh_solution_simd_wasm_bin.js": {
     "downloaded": 330166,
+    "total": 0
+  },
+  "face_mesh_solution_wasm_bin.wasm": {
+    "downloaded": 0,
+    "total": 0
+  },
+  "face_mesh_solution_simd_wasm_bin.wasm": {
+    "downloaded": 0,
     "total": 0
   },
   "face_mesh.binarypb": {
@@ -63,12 +87,24 @@
     "downloaded": 8002,
     "total": 0
   },
+  "pose_solution_packed_assets.data": {
+    "downloaded": 0,
+    "total": 0
+  },
   "pose_solution_wasm_bin.js": {
     "downloaded": 276473,
     "total": 0
   },
   "pose_solution_simd_wasm_bin.js": {
     "downloaded": 276478,
+    "total": 0
+  },
+  "pose_solution_wasm_bin.wasm": {
+    "downloaded": 0,
+    "total": 0
+  },
+  "pose_solution_simd_wasm_bin.wasm": {
+    "downloaded": 0,
     "total": 0
   },
   "pose_landmark_full.tflite": {

--- a/scripts/prepareOffline.js
+++ b/scripts/prepareOffline.js
@@ -14,22 +14,31 @@ const files = {
   // Additional assets required by the MediaPipe solutions
   // Hands
   'hands_solution_packed_assets_loader.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands_solution_packed_assets_loader.js',
+  'hands_solution_packed_assets.data': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands_solution_packed_assets.data',
   'hands_solution_wasm_bin.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands_solution_wasm_bin.js',
   'hands_solution_simd_wasm_bin.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands_solution_simd_wasm_bin.js',
+  'hands_solution_wasm_bin.wasm': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands_solution_wasm_bin.wasm',
+  'hands_solution_simd_wasm_bin.wasm': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands_solution_simd_wasm_bin.wasm',
   'hand_landmark_full.tflite': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hand_landmark_full.tflite',
   'hand_landmark_lite.tflite': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hand_landmark_lite.tflite',
   'hands.binarypb': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.binarypb',
 
   // Face Mesh
   'face_mesh_solution_packed_assets_loader.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh_solution_packed_assets_loader.js',
+  'face_mesh_solution_packed_assets.data': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh_solution_packed_assets.data',
   'face_mesh_solution_wasm_bin.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh_solution_wasm_bin.js',
   'face_mesh_solution_simd_wasm_bin.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh_solution_simd_wasm_bin.js',
+  'face_mesh_solution_wasm_bin.wasm': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh_solution_wasm_bin.wasm',
+  'face_mesh_solution_simd_wasm_bin.wasm': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh_solution_simd_wasm_bin.wasm',
   'face_mesh.binarypb': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.binarypb',
 
   // Pose
   'pose_solution_packed_assets_loader.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_solution_packed_assets_loader.js',
+  'pose_solution_packed_assets.data': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_solution_packed_assets.data',
   'pose_solution_wasm_bin.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_solution_wasm_bin.js',
   'pose_solution_simd_wasm_bin.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_solution_simd_wasm_bin.js',
+  'pose_solution_wasm_bin.wasm': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_solution_wasm_bin.wasm',
+  'pose_solution_simd_wasm_bin.wasm': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_solution_simd_wasm_bin.wasm',
   'pose_landmark_full.tflite': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_landmark_full.tflite',
   'pose_landmark_heavy.tflite': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_landmark_heavy.tflite',
   'pose_landmark_lite.tflite': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_landmark_lite.tflite',


### PR DESCRIPTION
## Summary
- extend `prepareOffline.js` to fetch wasm/data binaries
- track progress for new assets
- document additional asset sizes in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: config uses unsupported env key)*

------
https://chatgpt.com/codex/tasks/task_e_6853ad86b660833198a7696aceae0b5f