### PR TITLE
Fix MediaPipe module arguments

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,13 @@ import { formatSigns } from './handUtils.js';
 
 // Prepare global Module for MediaPipe WASM loaders
 if (!window.Module) {
-  window.Module = { arguments_: [] };
+  window.Module = {};
+}
+if (!('arguments_' in window.Module)) {
+  window.Module.arguments_ = [];
+}
+if (!('arguments' in window.Module)) {
+  window.Module.arguments = window.Module.arguments_;
 }
 
     // References


### PR DESCRIPTION
## Summary
- initialize global Module object with both `arguments_` and `arguments`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853b4567cfc8331a17c6fc7b4a69b5b