### PR TITLE
Fix tracker init if video already playing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -735,4 +735,5 @@ const transcriberP = pipeline('automatic-speech-recognition', 'Xenova/whisper-ti
       requestAnimationFrame(onFrame);
     }
     video.addEventListener('playing',onFrame);
+    if (!video.paused && video.readyState >= 2) requestAnimationFrame(onFrame);
 })();


### PR DESCRIPTION
## Summary
- ensure tracker loop starts even if video was playing before the listener was added

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853b8a2750483319dffbd5fe9c6e082