### PR TITLE
Traducción al español del menú de configuraciones

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -17,7 +17,7 @@ beforeAll(() => {
   const themeValue = document.getElementById('themeValue');
   themeToggle.addEventListener('click', () => {
     const isLight = document.body.classList.toggle('light');
-    themeValue.textContent = isLight ? 'Light' : 'Dark';
+    themeValue.textContent = isLight ? 'Claro' : 'Oscuro';
     localStorage.setItem('theme', isLight ? 'light' : 'dark');
   });
 

--- a/index.html
+++ b/index.html
@@ -44,32 +44,32 @@
   <div class="settings-screen" id="settingsScreen">
     <div class="settings-header">
       <button id="settingsBack" class="back-btn">←</button>
-      <span>Settings</span>
+      <span>Configuración</span>
     </div>
     <div class="settings-content">
       <div class="settings-section">
         <div class="group-title">General</div>
         <div class="settings-card">
-          <div class="settings-item"><div class="item-label">Theme</div><div class="item-value" id="themeValue">Light</div></div>
-          <div class="settings-item"><div class="item-label">Subtitle size</div><div class="item-control"><input type="range" min="12" max="24" value="16" id="subtitleSizeSlider"><div class="item-value" id="subtitleSizeValue">16 pt</div></div></div>
-          <div class="settings-item"><div class="item-label">Subtitle font</div><div class="item-control"><select id="subtitleFontSelect"><option value="sans-serif">Sans</option><option value="serif">Serif</option><option value="monospace">Mono</option></select></div></div>
-          <div class="settings-item"><div class="item-label">Subtitle color</div><div class="item-control"><input type="color" id="subtitleColorInput" value="#ffffff"></div></div>
-          <div class="settings-item"><div class="item-label">Haptics</div><label class="toggle-switch"><input type="checkbox" id="hapticsToggle" checked><span class="slider"></span></label></div>
+          <div class="settings-item"><div class="item-label">Tema</div><div class="item-value" id="themeValue">Claro</div></div>
+          <div class="settings-item"><div class="item-label">Tamaño de subtítulos</div><div class="item-control"><input type="range" min="12" max="24" value="16" id="subtitleSizeSlider"><div class="item-value" id="subtitleSizeValue">16 pt</div></div></div>
+          <div class="settings-item"><div class="item-label">Fuente de subtítulos</div><div class="item-control"><select id="subtitleFontSelect"><option value="sans-serif">Sans</option><option value="serif">Serif</option><option value="monospace">Mono</option></select></div></div>
+          <div class="settings-item"><div class="item-label">Color de subtítulos</div><div class="item-control"><input type="color" id="subtitleColorInput" value="#ffffff"></div></div>
+          <div class="settings-item"><div class="item-label">Vibración</div><label class="toggle-switch"><input type="checkbox" id="hapticsToggle" checked><span class="slider"></span></label></div>
           <div class="settings-item"><div class="item-label">Alto contraste</div><label class="toggle-switch"><input type="checkbox" id="contrastToggle"><span class="slider"></span></label></div>
         </div>
       </div>
       <div class="settings-section">
-        <div class="group-title">Offline Models</div>
+        <div class="group-title">Modelos sin conexión</div>
         <div class="settings-card">
-          <div class="settings-item"><div class="item-icon">💬</div><div class="item-info"><div class="item-label">Audio-STT</div><div class="item-sub">30 MB v0.3.2</div></div><button id="downloadSttBtn" class="settings-button primary">Download</button></div>
-          <div class="settings-item"><div class="item-icon">🤟</div><div class="item-info"><div class="item-label">LSA Translation</div><div class="item-sub">48 MB v0.6.1</div></div><button id="lsaSettingsBtn" class="settings-button secondary">Settings</button></div>
+          <div class="settings-item"><div class="item-icon">💬</div><div class="item-info"><div class="item-label">Audio-STT</div><div class="item-sub">30 MB v0.3.2</div></div><button id="downloadSttBtn" class="settings-button primary">Descargar</button></div>
+          <div class="settings-item"><div class="item-icon">🤟</div><div class="item-info"><div class="item-label">LSA Translation</div><div class="item-sub">48 MB v0.6.1</div></div><button id="lsaSettingsBtn" class="settings-button secondary">Configurar</button></div>
         </div>
       </div>
       <div class="settings-section">
-        <div class="group-title">Dialects</div>
+        <div class="group-title">Dialectos</div>
         <div class="settings-card">
           <div class="settings-item">
-            <div class="item-label">Dialect</div>
+            <div class="item-label">Dialecto</div>
             <div class="item-control">
               <select id="dialectSelect">
                 <option value="noroeste">Argentina</option>
@@ -81,14 +81,14 @@
         </div>
       </div>
       <div class="settings-section">
-        <div class="group-title">Devices</div>
+        <div class="group-title">Dispositivos</div>
         <div class="settings-card">
-          <div class="settings-item"><div class="item-label">Camera</div><div class="item-control"><select id="cameraSelect"></select></div></div>
-          <div class="settings-item"><div class="item-label">Microphone</div><div class="item-control"><select id="micSelect"></select></div></div>
+          <div class="settings-item"><div class="item-label">Cámara</div><div class="item-control"><select id="cameraSelect"></select></div></div>
+          <div class="settings-item"><div class="item-label">Micrófono</div><div class="item-control"><select id="micSelect"></select></div></div>
         </div>
       </div>
       <div class="settings-section">
-        <div class="group-title">Advanced</div>
+        <div class="group-title">Avanzado</div>
         <div class="settings-card">
           <button id="repeatTourBtn" class="settings-button secondary">Repetir tour</button>
           <button id="resetPrefsBtn" class="settings-button">Resetear preferencias</button>

--- a/src/app.js
+++ b/src/app.js
@@ -57,7 +57,7 @@ let hapticsEnabled = true;
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme === 'light') {
       document.body.classList.add('light');
-      themeValue.textContent = 'Light';
+      themeValue.textContent = 'Claro';
     }
 
     const savedContrast = localStorage.getItem('contrast');
@@ -242,7 +242,7 @@ Promise.all(tasks).then(() => {
     themeToggle.onclick=e=>{
       ripple(e,themeToggle);
       const isLight = document.body.classList.toggle('light');
-      themeValue.textContent = isLight ? 'Light' : 'Dark';
+      themeValue.textContent = isLight ? 'Claro' : 'Oscuro';
       localStorage.setItem('theme', isLight ? 'light' : 'dark');
     };
 
@@ -300,7 +300,7 @@ Promise.all(tasks).then(() => {
 
     if (resetPrefsBtn) resetPrefsBtn.onclick = e => {
       ripple(e, resetPrefsBtn);
-      if (confirm('Reset all preferences?')) {
+      if (confirm('¿Restablecer todas las preferencias?')) {
         localStorage.clear();
         location.reload();
       }
@@ -329,15 +329,15 @@ Promise.all(tasks).then(() => {
         const response = new Response(blob);
         const cache = await caches.open('offline-models');
         await cache.put(url, response);
-        downloadSttBtn.textContent = 'Downloaded ✓';
+        downloadSttBtn.textContent = 'Descargado ✓';
       } catch (err) {
-        downloadSttBtn.textContent = 'Failed';
+        downloadSttBtn.textContent = 'Error';
       }
     };
 
     if (lsaSettingsBtn) lsaSettingsBtn.onclick = e => {
       ripple(e, lsaSettingsBtn);
-      alert('Coming soon');
+      alert('Próximamente');
     };
 
     /* ---------- Mic ---------- */


### PR DESCRIPTION
## Summary
- traducir los nombres del menú de configuraciones al español
- actualizar textos de la lógica de la app y pruebas

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_685406211a608331af7ece800c3ff837