### PR TITLE
Re-enable MediaPipe CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
     if (!('arguments_' in Module)) Module.arguments_ = [];
     if (!('arguments' in Module)) Module.arguments = Module.arguments_;
   </script>
-  <script src="libs/hands.js"></script>
-  <script src="libs/face_mesh.js"></script>
-  <script src="libs/drawing_utils.js"></script>
-  <script src="libs/pose.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose.js"></script>
 </head>
 <body>
   <!-- Splash Screen -->

--- a/src/app.js
+++ b/src/app.js
@@ -574,31 +574,7 @@ Promise.all(tasks).then(() => {
       });
     })();
 async function ensureLibs() {
-  const res = await fetch(new URL('../libs/hands.js', import.meta.url), { method: 'HEAD' }).catch(() => null);
-  if (!res || !res.ok) {
-    const msg = document.createElement('div');
-    msg.id = 'fallbackLibs';
-    msg.className = 'fallback show';
-    msg.textContent = '⚠️ Falta libs. Ejecuta "npm run prepare-offline" o se usarán las URLs del CDN.';
-    document.body.appendChild(msg);
-    const cdn = [
-      'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js',
-      'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js',
-      'https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js',
-      'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose.js'
-    ];
-    for (const src of cdn) {
-      await new Promise(r => {
-        const s = document.createElement('script');
-        s.src = src;
-        s.onload = r;
-        s.onerror = r;
-        document.head.appendChild(s);
-      });
-    }
-    return import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2/dist/transformers.min.js');
-  }
-  return import(new URL('../libs/transformers.min.js', import.meta.url));
+  return import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2/dist/transformers.min.js');
 }
 
 const libsPromise = ensureLibs();

--- a/sw.js
+++ b/sw.js
@@ -7,11 +7,6 @@ const ASSETS = [
   '/src/sw-register.js',
   '/three.min.js',
   '/opencv.js',
-  '/libs/drawing_utils.js',
-  '/libs/face_mesh.js',
-  '/libs/hands.js',
-  '/libs/pose.js',
-  '/libs/transformers.min.js',
   '/enter.mp3',
   '/done.mp3',
 ];


### PR DESCRIPTION
## Summary
- load MediaPipe libraries from jsDelivr CDN
- simplify library detection logic
- remove unused local library references from service worker

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540ce0c47c8331afae36c479055d29