### PR TITLE
Add login overlay with credential validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,16 @@
   </div>
   <audio id="enter-sound" src="enter.mp3" preload="auto"></audio>
   <audio id="done-sound" src="done.mp3" preload="auto"></audio>
-  <script type="module">
-    import { initSplash } from "./src/splash.js";
-    initSplash(document.getElementById("splash"));
-  </script>
+  <div id="loginOverlay" class="login-overlay">
+    <form id="loginForm" class="login-form">
+      <h1>SeñAR</h1>
+      <input id="username" type="text" placeholder="Usuario" required>
+      <input id="password" type="password" placeholder="Contraseña" required>
+      <button type="submit">Ingresar</button>
+      <button type="button" id="bioBtn" style="display:none">Biometría</button>
+      <div id="loginError" class="login-error"></div>
+    </form>
+  </div>
 
   <!-- Guided Tour -->
   <div class="tour-overlay" id="tourOverlay">
@@ -133,9 +139,7 @@
   </div>
 
 
-  <script src="src/app.js" type="module" defer></script>
-  <!-- Whisper tiny (q8) local + Tracker Combinado -->
-  <script src="src/sw-register.js" type="module"></script>
+  <script src="src/login.js" type="module"></script>
 </body>
 </html>
 

--- a/libs/tester-access.json
+++ b/libs/tester-access.json
@@ -1,0 +1,5 @@
+[
+  {"username": "Admin", "password": "<hash>"},
+  {"username": "Tester", "password": "<hash>"},
+  {"username": "Usuario", "password": "<hash>"}
+]

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,89 @@
+export async function startApp() {
+  const { initSplash } = await import('./splash.js');
+  initSplash(document.getElementById('splash'));
+  await import('./app.js');
+  import('./sw-register.js');
+}
+
+async function getUsers() {
+  const res = await fetch('libs/tester-access.json');
+  return res.ok ? res.json() : [];
+}
+
+function storeCredentials(id, password) {
+  if ('credentials' in navigator && window.PasswordCredential) {
+    try {
+      const cred = new window.PasswordCredential({ id, password });
+      navigator.credentials.store(cred).catch(() => {});
+    } catch {}
+  }
+}
+
+async function attemptAutoLogin(users) {
+  if ('credentials' in navigator && window.PasswordCredential) {
+    try {
+      const cred = await navigator.credentials.get({ password: true });
+      if (cred) {
+        const ok = users.some(u => u.username === cred.id && u.password === cred.password);
+        if (ok) {
+          storeCredentials(cred.id, cred.password);
+          return { ok: true, user: cred.id };
+        }
+      }
+    } catch {}
+  }
+  return { ok: false };
+}
+
+function showError(msg) {
+  const el = document.getElementById('loginError');
+  if (el) el.textContent = msg;
+}
+
+async function handleSubmit(e, users) {
+  e.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value;
+  const valid = users.some(u => u.username === username && u.password === password);
+  if (valid) {
+    storeCredentials(username, password);
+    await loginSuccess();
+  } else {
+    showError('Credenciales inválidas');
+  }
+}
+
+async function loginSuccess() {
+  const overlay = document.getElementById('loginOverlay');
+  overlay.classList.add('hidden');
+  await startApp();
+}
+
+function setupBiometrics(users) {
+  const btn = document.getElementById('bioBtn');
+  if (!btn || !window.PublicKeyCredential) return;
+  btn.style.display = 'block';
+  btn.addEventListener('click', async () => {
+    try {
+      await navigator.credentials.get({
+        publicKey: {
+          challenge: new Uint8Array(16),
+          timeout: 60000,
+          userVerification: 'preferred'
+        }
+      });
+      await loginSuccess();
+    } catch {
+      showError('Biometría cancelada');
+    }
+  });
+}
+
+(async () => {
+  const users = await getUsers();
+  const form = document.getElementById('loginForm');
+  form.addEventListener('submit', e => handleSubmit(e, users));
+  setupBiometrics(users);
+  const { ok } = await attemptAutoLogin(users);
+  if (ok) await loginSuccess();
+})();

--- a/styles.css
+++ b/styles.css
@@ -112,6 +112,49 @@ body.light {
       position: relative;
       z-index: 1002;
     }
+    /* Login Overlay */
+    .login-overlay {
+      position: fixed;
+      inset: 0;
+      background: var(--bg-overlay);
+      backdrop-filter: blur(6px);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1500;
+      transition: opacity var(--transition);
+    }
+    .login-overlay.hidden { opacity: 0; pointer-events: none; }
+    .login-form {
+      background: var(--control-bg);
+      color: var(--text-light);
+      padding: calc(var(--spacing)*3);
+      border-radius: var(--radius);
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing);
+      width: 280px;
+      animation: fadeIn 0.4s ease-out;
+    }
+    .login-form h1 { text-align: center; margin: 0 0 var(--spacing); }
+    .login-form input {
+      padding: var(--spacing);
+      border-radius: var(--radius);
+      border: none;
+      font-size: var(--font-base);
+    }
+    .login-form button {
+      padding: var(--spacing);
+      border: none;
+      border-radius: var(--radius);
+      background: var(--accent);
+      color: var(--text-light);
+      cursor: pointer;
+      transition: transform 0.2s var(--transition), background var(--transition);
+    }
+    .login-form button:hover { transform: scale(1.05); }
+    .login-form button:active { transform: scale(0.95); }
+    .login-error { min-height: 1em; color: var(--error); text-align: center; }
     /* Controls Left */
     .controls-left {
       position: absolute; top: 5%; left: 2%;
@@ -448,6 +491,10 @@ body.light {
       .mic-button {
         width: 60px;
         height: 60px;
+      }
+
+      .login-form {
+        width: 90%;
       }
 
   .fps-badge {


### PR DESCRIPTION
## Summary
- create `tester-access.json` with sample user credentials
- add `login.js` to validate user/password and start the app after login
- inject a login overlay form into `index.html`
- load the app modules only after authentication
- style the login form and make it responsive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68542b22f8c883318e04c25768d04868