### PR TITLE
Fix duplicate video overlay

### DIFF
--- a/src/tracker.js
+++ b/src/tracker.js
@@ -62,7 +62,8 @@ export function initTracker({
       ctx.clearRect(0, 0, cw, ch);
       ctx.translate(cw, 0);
       ctx.scale(-1, 1);
-      ctx.drawImage(video, 0, 0, vw, vh, dx, dy, dw, dh);
+      // The HTML video element already displays the camera feed.
+      // Draw only overlays here so the video isn't duplicated.
 
       handLandmarks.forEach(landmarks => {
         ctx.strokeStyle = '#00FF00';


### PR DESCRIPTION
## Summary
- avoid drawing the video frame again on the tracker canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545bee59688331b83a724538644ef0