### PR TITLE
Reuse audio contexts for audio conversion

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -563,13 +563,14 @@ const device = navigator.gpu ? 'webgpu' : 'wasm';
 const transcriberP = pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny', { quantized: true, device });
 // Reuse existing element references defined at the top of the file
     let recorder,chunks=[],blob;
+    const ac=new AudioContext();
+    let off;
     async function blobToPCM(b,r=16000){
       const buf=await b.arrayBuffer();
-      const ac=new AudioContext();
       const dec=await ac.decodeAudioData(buf);
       if(dec.sampleRate===r)return dec.getChannelData(0);
       const frames=Math.ceil(dec.duration*r);
-      const off=new OfflineAudioContext(1,frames,r);
+      off=new OfflineAudioContext(1,frames,r);
       const src=off.createBufferSource();src.buffer=dec;
       src.connect(off.destination);src.start();
       const res=await off.startRendering();


### PR DESCRIPTION
## Summary
- reuse a single `AudioContext` instance for decoding
- hold an `OfflineAudioContext` variable outside `blobToPCM` for resampling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68546b9174748331825de054495bfa2d