### PR TITLE
Fix MediaPipe initialization for hand tracking

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -608,7 +608,7 @@ const transcriberP = pipeline('automatic-speech-recognition', 'Xenova/whisper-ti
     micBtn.addEventListener('click', recordHandler);
 
     const { initTracker } = await import('./tracker.js');
-    initTracker({
+    await initTracker({
       video,
       canvas: document.getElementById('trackerCanvas')
     });

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -13,7 +13,7 @@ export const trackerState = {
 export const LEFT_EYE_IDX = [33, 133, 159, 145];
 export const RIGHT_EYE_IDX = [362, 263, 386, 374];
 
-export function initTracker({
+export async function initTracker({
   video,
   canvas
 }) {
@@ -35,6 +35,7 @@ export function initTracker({
   if (!mpCache.handsInitialized) {
     hands.setOptions({ maxNumHands: 2, modelComplexity: 1,
       minDetectionConfidence: 0.7, minTrackingConfidence: 0.7 });
+    await hands.initialize();
     mpCache.handsInitialized = true;
   }
   const faceMesh = mpCache.faceMesh || (mpCache.faceMesh = new FaceMesh(
@@ -43,6 +44,7 @@ export function initTracker({
   if (!mpCache.faceMeshInitialized) {
     faceMesh.setOptions({ maxNumFaces: 1, refineLandmarks: true,
       minDetectionConfidence: 0.7, minTrackingConfidence: 0.7 });
+    await faceMesh.initialize();
     mpCache.faceMeshInitialized = true;
   }
   let handLandmarks = [], faceResults = null;


### PR DESCRIPTION
## Summary
- ensure Hands and FaceMesh initialize before starting the tracker
- wait for `initTracker` in the main app loader

## Testing
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546e1575c08331b944060da6bc1e97