### PR TITLE
Optimize theme color retrieval

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -217,6 +217,7 @@ Promise.all(tasks).then(() => {
       const isLight = document.body.classList.toggle('light');
       themeValue.textContent = isLight ? 'Claro' : 'Oscuro';
       localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      window.dispatchEvent(new Event('themechange'));
     };
 
     if (contrastToggle) contrastToggle.onclick = e => {
@@ -224,6 +225,7 @@ Promise.all(tasks).then(() => {
       const enabled = contrastToggle.checked;
       document.body.classList.toggle('high-contrast', enabled);
       localStorage.setItem('contrast', enabled);
+      window.dispatchEvent(new Event('themechange'));
     };
 
     if (hapticsToggle) hapticsToggle.onclick = e => {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -13,6 +13,23 @@ export const trackerState = {
 export const LEFT_EYE_IDX = [33, 133, 159, 145];
 export const RIGHT_EYE_IDX = [362, 263, 386, 374];
 
+// Retrieve theme colors once and update when a theme change is detected
+function getAppColors() {
+  const styles = getComputedStyle(document.documentElement);
+  const accent = styles.getPropertyValue('--accent').trim() || '#2EB8A3';
+  const icon = styles.getPropertyValue('--icon-color').trim() || '#FFFFFF';
+  return { accent, icon };
+}
+
+let currentColors = getAppColors();
+
+export function updateTrackerColors() {
+  currentColors = getAppColors();
+}
+
+// Update colors whenever the theme changes
+window.addEventListener('themechange', updateTrackerColors);
+
 export async function initTracker({
   video,
   canvas
@@ -55,16 +72,9 @@ export async function initTracker({
   });
   faceMesh.onResults(r => { faceResults = r; });
 
-  function getAppColors() {
-    const styles = getComputedStyle(document.documentElement);
-    const accent = styles.getPropertyValue('--accent').trim() || '#2EB8A3';
-    const icon = styles.getPropertyValue('--icon-color').trim() || '#FFFFFF';
-    return { accent, icon };
-  }
-
     async function onFrame() {
       if (video.readyState >= 2) {
-        const { accent, icon } = getAppColors();
+        const { accent, icon } = currentColors;
         await Promise.all([
           hands.send({ image: video }),
           faceMesh.send({ image: video })


### PR DESCRIPTION
## Summary
- cache theme colors in tracker and update on themechange events
- dispatch themechange event from settings toggles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854709fce5c833194d94ce464d31bfa