### PR TITLE
Optimize audio and worker loading

### DIFF
--- a/src/transcribeWorker.js
+++ b/src/transcribeWorker.js
@@ -1,0 +1,44 @@
+import { pipeline } from '../libs/transformers.min.js';
+
+let transcriber;
+
+async function ensurePipeline() {
+  if (!transcriber) {
+    const device = self.navigator && self.navigator.gpu ? 'webgpu' : 'wasm';
+    transcriber = pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny', {
+      quantized: true,
+      device
+    });
+  }
+  return transcriber;
+}
+
+async function blobToPCM(blob, rate = 16000) {
+  const ac = new AudioContext();
+  let off;
+  try {
+    const buf = await blob.arrayBuffer();
+    const dec = await ac.decodeAudioData(buf);
+    if (dec.sampleRate === rate) {
+      return dec.getChannelData(0).slice();
+    }
+    const frames = Math.ceil(dec.duration * rate);
+    off = new OfflineAudioContext(1, frames, rate);
+    const src = off.createBufferSource();
+    src.buffer = dec;
+    src.connect(off.destination);
+    src.start();
+    const res = await off.startRendering();
+    off.close && off.close();
+    return res.getChannelData(0).slice();
+  } finally {
+    ac.close();
+  }
+}
+
+self.onmessage = async e => {
+  const pcm = await blobToPCM(e.data);
+  const p = await ensurePipeline();
+  const { text } = await (await p)(pcm, { chunk_length_s: 30, language: 'spanish' });
+  self.postMessage(text.trim());
+};

--- a/sw.js
+++ b/sw.js
@@ -5,8 +5,13 @@ const ASSETS = [
   '/styles.css',
   '/src/app.js',
   '/src/sw-register.js',
+  '/src/transcribeWorker.js',
   '/enter.mp3',
   '/done.mp3',
+  '/libs/hands.js',
+  '/libs/face_mesh.js',
+  '/libs/drawing_utils.js',
+  '/libs/transformers.min.js',
 ];
 self.addEventListener('install', evt => {
   evt.waitUntil(
@@ -21,6 +26,19 @@ self.addEventListener('activate', evt => {
   );
 });
 self.addEventListener('fetch', evt => {
+  const url = new URL(evt.request.url);
+  if (url.origin === location.origin && url.pathname.startsWith('/libs/')) {
+    evt.respondWith(
+      caches.open('offline-models').then(async cache => {
+        const cached = await cache.match(evt.request);
+        if (cached) return cached;
+        const res = await fetch(evt.request);
+        if (res.ok) cache.put(evt.request, res.clone());
+        return res;
+      })
+    );
+    return;
+  }
   evt.respondWith(
     caches.match(evt.request).then(resp => resp || fetch(evt.request))
   );


### PR DESCRIPTION
## Summary
- precache libraries in the service worker and serve them from cache
- offload Whisper transcription to a new Web Worker
- throttle progress bar DOM updates
- close audio contexts after use

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685473e49e8483318bc8efc9f83a7745