### PR TITLE
Fix worker detection without cross‑origin isolation

### DIFF
--- a/src/tracker.js
+++ b/src/tracker.js
@@ -31,7 +31,10 @@ export function updateTrackerColors() {
 window.addEventListener('themechange', updateTrackerColors);
 
 const FRAME_INTERVAL = 1000 / 15;
-const CAN_USE_WORKER = typeof OffscreenCanvas !== 'undefined' && typeof Worker !== 'undefined' && typeof createImageBitmap !== 'undefined';
+const CAN_USE_WORKER = typeof OffscreenCanvas !== 'undefined' &&
+  typeof Worker !== 'undefined' &&
+  typeof createImageBitmap !== 'undefined' &&
+  window.crossOriginIsolated === true;
 
 export async function initTracker({
   video,


### PR DESCRIPTION
## Summary
- ensure tracker only uses worker when cross‑origin isolation is active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685493236c6483319e806dc8985222ba