### PR TITLE
Add wasm assets to service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -12,6 +12,12 @@ const ASSETS = [
   '/libs/face_mesh.js',
   '/libs/drawing_utils.js',
   '/libs/transformers.min.js',
+  '/libs/hands_solution_wasm_bin.wasm',
+  '/libs/hands_solution_simd_wasm_bin.wasm',
+  '/libs/face_mesh_solution_wasm_bin.wasm',
+  '/libs/face_mesh_solution_simd_wasm_bin.wasm',
+  '/libs/pose_solution_wasm_bin.wasm',
+  '/libs/pose_solution_simd_wasm_bin.wasm',
 ];
 self.addEventListener('install', evt => {
   evt.waitUntil(


### PR DESCRIPTION
## Summary
- cache MediaPipe wasm modules in the service worker

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars etc.)*
- `DRY_RUN=1 npm run prepare-offline`


------
https://chatgpt.com/codex/tasks/task_e_6854ad930a3c83318264572002b3d6eb