### PR TITLE
Add offline resume test

### DIFF
--- a/__tests__/offlineResume.test.js
+++ b/__tests__/offlineResume.test.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const https = require('https');
+const { TextEncoder, TextDecoder } = require('util');
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+const key = `-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDBPpzKw5r1+TRd
+l5gfXM7qU1JdYxtNOW6mMVNgENE5dtwtceW+5m1e1wMbWulR3h5Wrdt5xTKrzZw+
+MdHpsugAdTqxe+xOK87qhfp39ETiB6cqQnKjkumv0IN9AiWkB+NhchDyD9K0DnD0
+NGIdut/0iJWkuA930OtPwZoWyub5/86ymr0/Lo9GmESkyd2I04f5+RQOe0Wdcbaj
+xQzdSthds3NZWdHnhcsPXxfR9u4vsWF8yMXerahKwLIrLCc17wNQFUbHxaFRAmqw
+L++lgDIpmkqiPMlFI5tlRUBqaM2HUyV4uQ0HXxA/jKc+W/O63+KeNrCBy+N9yqdz
+V0dFFg9XAgMBAAECggEAVm7r8GFXMUe6nVYNy5FWV0bXYz/N2Vej3x/W2/QJsPsx
+9f2oth8Ysj/XeufJzj1cMobm0OtcA64egU8FRdMoo/PLQdFc24YKsaklY3vVR4gG
+xAcegX1XmrTX6xUHwvtoP5Cmda6QHssKyJ+ZdxS70QM6c4eEG6JNbcn5YtJ0R0LV
+hoqBcn8vPgSociPsW31WVDLBCTJH9Iv0F0NqYV6eWptr6cs7UV40uVQtPyTb1DUh
+orSZqRRAaR8ZSdXfBLSyl5D17xR5GvSbCajZcq1JRCXfWkQRP9fgaxIFUOsSE4rl
+EcOLZgLGPDEbdSiU/+zPxXBiBq6yeoP8D1+fb0IFsQKBgQDob5rnVDEWcRGoW4Ru
+9X7WNz+LBIILKbyNXL8mgk5aKC6DPo7g464bCwTgUj9mkZ1KYTroLGQlL6AuPPzX
+e81QAspIVOjpwkDLOlrBGrgdazbTGK1HBtUTxSeQKrNzx2O+kjmOSCmk3ljNBBGi
+PHlfMepEzJLbX/CiWTg0w1XbKQKBgQDU1eBMt6QxiI9UvpvlcPNNSavf1MjqC7ZG
+BpERiOxxjXCMvmSTwVwgrlR7kocPXiRjVWJadqpegpPaUjBRKby/0IGgEThT98A7
+/n4peOFs9sdGmDYgnUNbikLoEqQcbX4pCVaxC8ftdoAJTEoSih0NIMD/cvKu8FId
+mIw7WExmfwKBgQCntbdoSHguwCDEgFwbD6mX+T8xGGyYj2HMAequZ4EPTkTZT+8Z
+104NlzLKhK3YXSLHw0YUtcsAhc+m7TxmYp6up4S7EgEIga/ss0s+YAAOwghJ4llM
+kWJ3JF86h4T5+hk/LRS4U9swaXpbWx86FzZf+I0XXSBth1kCWyvR7ktpmQKBgQCR
+NiNE9H6YNR3lqe7fikLV1o/ntVwnIzqHaG+N0SfRCblirXwdu21J9uc5MG3ptEeL
+ZnQmWJRAy0JpUG4a0ikvjekC9vzBfWWxCR+21/ylxXGM3sj/U4zjZd/kSuOhaasM
+AI0fWnRbteABeAWJxKWxkUlcgGbHqLu96Ziz3LizrQKBgQC9q6LCYQUrKHYYNku8
+ioMw33/2UMEGZLEGNUd7DU01XzxIJ4ejflnX0/wYwyRmNNGCHCLUT5NKkBZJ47VY
+piIdmzWu4l245vmesoYKlJFcjkg7d9bB9PXyHFmKRMo3BaPgNfYP6vzpMkzukbIs
+1AXzFGTYa7xqJy/cQ2gne8YRfw==
+-----END PRIVATE KEY-----`;
+
+const cert = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUYC9hM8r4R0ifTIs/9H+Pq8qKlQUwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDYyMDAwNDczNVoXDTI1MDYy
+MTAwNDczNVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAwT6cysOa9fk0XZeYH1zO6lNSXWMbTTlupjFTYBDROXbc
+LXHlvuZtXtcDG1rpUd4eVq3becUyq82cPjHR6bLoAHU6sXvsTivO6oX6d/RE4gen
+KkJyo5Lpr9CDfQIlpAfjYXIQ8g/StA5w9DRiHbrf9IiVpLgPd9DrT8GaFsrm+f/O
+spq9Py6PRphEpMndiNOH+fkUDntFnXG2o8UM3UrYXbNzWVnR54XLD18X0fbuL7Fh
+fMjF3q2oSsCyKywnNe8DUBVGx8WhUQJqsC/vpYAyKZpKojzJRSObZUVAamjNh1Ml
+eLkNB18QP4ynPlvzut/injawgcvjfcqnc1dHRRYPVwIDAQABo1MwUTAdBgNVHQ4E
+FgQUkjC43zCnZJYNjMOE4GjriMukVyMwHwYDVR0jBBgwFoAUkjC43zCnZJYNjMOE
+4GjriMukVyMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAVzK7
+BGtLZ5MHSNSGGsttmPbHaDL/CP6xIJ9dm5R1PL+LQNSUu8cgc0He/2elu1RLJIj1
+KknxLDX2qh7i/+MVm2GJlB2TOKsErdBMSmwhoQVWqwi5UL9nGNwwoqYXvnDTmc0R
+g8xolngLkOdquY1GB8cYvC176zhMW0mMe35o2h4yYvM8W97zMVDtWcNJL4frH1T6
+XKPLFdamYGOZzmzdzqk6+wFxbH9rV3w2W6pirdD6dd3wtSEPITENcxH8zDINruSz
+WHYgV/G7/DiFWsCBRRSFUI5AdvV5/Iqp8ZO+flg1tY06C4aH2OlWY1/GAutbmChn
+Piezcl4e+9llhWAPYQ==
+-----END CERTIFICATE-----`;
+
+const fileData = Buffer.from('HelloWorldHelloWorld');
+
+function setupDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'offline-'));
+}
+
+function writeProgress(dir, downloaded, total) {
+  const progressPath = path.join(dir, 'progress.json');
+  fs.writeFileSync(progressPath, JSON.stringify({ 'test.bin': { downloaded, total } }, null, 2));
+}
+
+test('downloads resume and update progress file', async () => {
+  const dir = setupDir();
+  fs.writeFileSync(path.join(dir, 'test.bin'), fileData.slice(0, 10));
+  writeProgress(dir, 10, 20);
+
+  process.env.LIBS_DIR = dir;
+  delete process.env.DRY_RUN;
+
+  const server = https.createServer({ key, cert }, (req, res) => {
+    const range = req.headers.range;
+    const start = range ? parseInt(range.replace(/bytes=(\d+)-/, '$1'), 10) : 0;
+    const chunk = fileData.slice(start);
+    res.writeHead(range ? 206 : 200, { 'Content-Length': chunk.length });
+    res.end(chunk);
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const url = `https://localhost:${server.address().port}/test.bin`;
+  process.env.FILES_OVERRIDE = JSON.stringify({ 'test.bin': url });
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  https.globalAgent.options.rejectUnauthorized = false;
+  await require('../scripts/prepareOffline.js')();
+  server.close();
+
+  const finalData = fs.readFileSync(path.join(dir, 'test.bin'));
+  expect(finalData.equals(fileData)).toBe(true);
+  const progress = JSON.parse(fs.readFileSync(path.join(dir, 'progress.json'), 'utf8'));
+  expect(progress['test.bin'].downloaded).toBe(fileData.length);
+  expect(progress['test.bin'].total).toBe(fileData.length);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "eslint": "^8.57.1",
         "esm": "^3.2.25",
         "jest": "^30.0.0",
-        "jest-environment-jsdom": "^30.0.0"
+        "jest-environment-jsdom": "^30.0.0",
+        "nock": "^14.0.5"
       },
       "engines": {
         "node": ">=20"
@@ -1408,6 +1409,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.38.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.7.tgz",
+      "integrity": "sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -1458,6 +1477,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3582,6 +3626,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4777,6 +4828,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5014,6 +5072,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.5.tgz",
+      "integrity": "sha512-R49fALR9caB6vxuSWUIaK2eBYeTloZQUFBZ4rHO+TbhMGQHtwnhdqKLYki+o+8qMgLvoBYWrp/2KzGPhxL4S6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.38.7",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5101,6 +5174,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -5342,6 +5422,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/punycode": {
@@ -5667,6 +5757,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eslint": "^8.57.1",
     "esm": "^3.2.25",
     "jest": "^30.0.0",
-    "jest-environment-jsdom": "^30.0.0"
+    "jest-environment-jsdom": "^30.0.0",
+    "nock": "^14.0.5"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/scripts/prepareOffline.js
+++ b/scripts/prepareOffline.js
@@ -2,7 +2,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 
-const files = {
+const defaultFiles = {
   // Core MediaPipe wrappers
   'hands.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js',
   'face_mesh.js': 'https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js',
@@ -45,6 +45,10 @@ const files = {
   'pose_web.binarypb': 'https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose_web.binarypb'
 };
 
+const files = process.env.FILES_OVERRIDE
+  ? JSON.parse(process.env.FILES_OVERRIDE)
+  : defaultFiles;
+
 function download(opts, dest, onProgress) {
   const { url, headers = {} } = typeof opts === 'string' ? { url: opts } : opts;
   return new Promise((resolve, reject) => {
@@ -69,7 +73,7 @@ function download(opts, dest, onProgress) {
 }
 
 async function main() {
-  const dir = path.join(__dirname, '..', 'libs');
+  const dir = process.env.LIBS_DIR || path.join(__dirname, '..', 'libs');
   fs.mkdirSync(dir, { recursive: true });
   const progressPath = path.join(dir, 'progress.json');
   let progress = {};


### PR DESCRIPTION
## Summary
- allow overriding file list and libs folder in `prepareOffline.js`
- test resuming downloads with a local HTTPS server
- install `nock` for other tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ae86952c83318c75d492c2e03a3c