### PR TITLE
Improve service worker offline strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ docker run -p 80:80 -p 443:443 senar
 
 ### Actualizar el service worker
 
-Cuando se modifique `sw.js` o cambien los archivos estáticos, incremente la constante `CACHE_NAME` y despliegue nuevamente. Al cargar la página, el registro en `src/sw-register.js` mostrará un aviso para recargar y activar la versión nueva.
+Cuando se modifique `sw.js` o cambien los archivos estáticos, incremente la constante `CACHE_VERSION` y despliegue nuevamente. Al cargar la página, el registro en `src/sw-register.js` mostrará un aviso para recargar y activar la versión nueva.
 
 ### Renovar los modelos offline
 

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Modo sin conexión</h1>
+  <p>No hay conexión a internet. Algunas funciones pueden no estar disponibles.</p>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,7 @@
-const CACHE_NAME = 'sear-cache-v1';
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `sear-cache-${CACHE_VERSION}`;
+const MODEL_CACHE = 'offline-models';
+const OFFLINE_URL = '/offline.html';
 const ASSETS = [
   '/',
   '/index.html',
@@ -8,6 +11,7 @@ const ASSETS = [
   '/src/transcribeWorker.js',
   '/enter.mp3',
   '/done.mp3',
+  '/offline.html',
   '/libs/hands.js',
   '/libs/face_mesh.js',
   '/libs/drawing_utils.js',
@@ -23,33 +27,77 @@ self.addEventListener('install', evt => {
   evt.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
   );
+  self.skipWaiting();
 });
 self.addEventListener('activate', evt => {
   evt.waitUntil(
     caches.keys().then(keys => Promise.all(
-      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+      keys.filter(k => k !== CACHE_NAME && k !== MODEL_CACHE)
+        .map(k => caches.delete(k))
     ))
   );
+  self.clients.claim();
 });
 self.addEventListener('fetch', evt => {
+  if (evt.request.method !== 'GET') return;
   const url = new URL(evt.request.url);
+
   if (url.origin === location.origin && url.pathname.startsWith('/libs/')) {
     evt.respondWith(
-      caches.open('offline-models').then(async cache => {
-        const cached = await cache.match(evt.request);
-        if (cached) return cached;
-        const res = await fetch(evt.request);
-        if (res.ok) cache.put(evt.request, res.clone());
-        return res;
+      caches.open(MODEL_CACHE).then(async cache => {
+        try {
+          const res = await fetch(evt.request);
+          if (res.ok) cache.put(evt.request, res.clone());
+          return res;
+        } catch (err) {
+          const cached = await cache.match(evt.request);
+          if (cached) return cached;
+          return caches.match(OFFLINE_URL);
+        }
       })
     );
     return;
   }
-  evt.respondWith(
-    caches.match(evt.request).then(resp => resp || fetch(evt.request))
-  );
+
+  if (url.origin === location.origin && url.pathname.endsWith('.html')) {
+    evt.respondWith(networkFirst(evt.request));
+    return;
+  }
+
+  evt.respondWith(cacheFirst(evt.request));
 });
 
 self.addEventListener('message', evt => {
   if (evt.data === 'SKIP_WAITING') self.skipWaiting();
 });
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  try {
+    const res = await fetch(request);
+    if (res && res.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, res.clone());
+    }
+    return res;
+  } catch (err) {
+    return caches.match(OFFLINE_URL);
+  }
+}
+
+async function networkFirst(request) {
+  try {
+    const res = await fetch(request);
+    if (res && res.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, res.clone());
+      return res;
+    }
+    throw new Error('Network error');
+  } catch (err) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    return caches.match(OFFLINE_URL);
+  }
+}


### PR DESCRIPTION
## Summary
- implement cache versioning and offline fallback
- support cache-first / network-first strategies
- document new `CACHE_VERSION` constant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b177e2f88331ab59a8484609cb5a