### PR TITLE
Add dry-run offline prep script

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ Para ejecutar la demo sin conexión:
    ```
 
 2. Si solo desea verificar el proceso sin descargar los archivos reales,
-  ejecute `DRY_RUN=1 npm run prepare-offline`, lo que genera las entradas de
-  `progress.json` sin realizar descargas.
+   ejecute `npm run prepare-offline:dry` (equivalente a
+   `DRY_RUN=1 npm run prepare-offline`). Este modo genera las entradas de
+   `progress.json` sin realizar descargas.
 3. Reserve alrededor de **80 MB** de espacio libre para los modelos y asegúrese
    de que los archivos se sirvan también mediante **HTTPS**.
 4. El script también descarga archivos `.wasm` y `.data` necesarios para las

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest",
     "start": "npx http-server . -p 8000",
     "lint": "eslint -c .eslintrc.cjs \"src/**/*.js\" \"__tests__/**/*.js\"",
-    "prepare-offline": "node scripts/prepareOffline.js"
+    "prepare-offline": "node scripts/prepareOffline.js",
+    "prepare-offline:dry": "DRY_RUN=1 node scripts/prepareOffline.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `prepare-offline:dry` npm script
- explain dry-run mode in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b3881ce48331b6556cbf8141c8af