### PR TITLE
Add web manifest and privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,8 @@ Para revisarlas y fusionarlas:
 1. Revisar la descripción de la PR y los *changelogs* enlazados.
 2. Ejecutar localmente `npm ci` y `npm test` para asegurarse de que la actualización no rompe la aplicación.
 3. Si todo funciona correctamente, usar **Squash and merge** y eliminar la rama de Dependabot.
+
+## Política de Privacidad
+
+La aplicación procesa video y audio localmente en su navegador. No se envían datos de cámara ni micrófono a servidores externos. Para más detalles consulte [docs/privacy.md](docs/privacy.md).
+

--- a/Splash.html
+++ b/Splash.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <title>SeñAR – Splash Canvas Mejorado</title>
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#ffffff">
   <style>
     * { margin:0; padding:0; box-sizing:border-box }
     html, body { width:100%; height:100%; overflow:hidden; background:#F9F9FC; font-family:'Helvetica Neue', sans-serif; }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,7 @@
+# Política de Privacidad
+
+Esta aplicación utiliza la cámara y el micrófono únicamente para procesar las imágenes y el audio de forma local en su dispositivo. Ningún dato capturado se envía a servidores externos.
+
+Los modelos de reconocimiento se descargan y almacenan en la caché del navegador para habilitar el modo sin conexión. Puede eliminar estos datos desde las herramientas de desarrollo o borrando el almacenamiento del sitio.
+
+No se recopila información personal ni se comparte con terceros.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>SeñAR Web App</title>
   <link rel="stylesheet" href="styles.css">
   <link rel="icon" href="favicon.ico">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- MediaPipe libraries for Tracker Combinado -->
   <script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "SeñAR Web App",
+  "short_name": "SeñAR",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "48x48 96x96 144x144",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/offline.html
+++ b/offline.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Offline</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#ffffff">
 </head>
 <body>
   <h1>Modo sin conexión</h1>


### PR DESCRIPTION
## Summary
- add Web App Manifest with icons and theme color
- reference manifest and theme color meta in HTML files
- document privacy policy
- remove binary icons from repo and use favicon in manifest

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854b4e838ac83318dafb87207c4bb65