### PR TITLE
Add dynamic sign detection module

### DIFF
--- a/__tests__/dynamicSigns.test.js
+++ b/__tests__/dynamicSigns.test.js
@@ -1,0 +1,35 @@
+const { updateTrails, detectDynamicSigns, resetTrails } = require('../src/dynamicSigns.cjs');
+
+function frame(x, y){
+  const lm = Array.from({ length: 21 }, () => ({ x: 0, y: 0 }));
+  lm[20] = { x, y };
+  return lm;
+}
+
+test('detects letter J trajectory', () => {
+  resetTrails();
+  const seq = [
+    frame(0.5,0.5),
+    frame(0.5,0.6),
+    frame(0.45,0.7),
+    frame(0.4,0.65),
+    frame(0.38,0.6)
+  ];
+  seq.forEach(f => updateTrails([f]));
+  const out = detectDynamicSigns();
+  expect(out[0]).toBe('J');
+});
+
+test('detects letter Z trajectory', () => {
+  resetTrails();
+  const seq = [
+    frame(0.2,0.2),
+    frame(0.3,0.2),
+    frame(0.25,0.25),
+    frame(0.35,0.25),
+    frame(0.45,0.25)
+  ];
+  seq.forEach(f => updateTrails([f]));
+  const out = detectDynamicSigns();
+  expect(out[0]).toBe('Z');
+});

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,9 @@ import { initCamera, startStream } from './camera.js';
 import { initCaptionDrag } from './drag.js';
 import { initMic } from './mic.js';
 import { initTour } from './tour.js';
+import { detectStaticSign } from './staticSigns.js';
+import { updateTrails, detectDynamicSigns } from './dynamicSigns.js';
+import { trackerState } from './tracker.js';
 
 if (!window.Module) window.Module = {};
 if (!('arguments_' in window.Module)) window.Module.arguments_ = [];
@@ -199,4 +202,13 @@ Promise.all(tasks).then(() => {
     video,
     canvas: document.getElementById('trackerCanvas')
   });
+  function detectLoop(){
+    const hands = trackerState.handLandmarks || [];
+    updateTrails(hands);
+    const dyn = detectDynamicSigns();
+    const out = hands.map((lm, i) => dyn[i] || detectStaticSign(lm));
+    if (out.some(Boolean)) console.log('Signs:', out.filter(Boolean).join(' '));
+    requestAnimationFrame(detectLoop);
+  }
+  requestAnimationFrame(detectLoop);
 })();

--- a/src/dynamicSigns.cjs
+++ b/src/dynamicSigns.cjs
@@ -1,0 +1,51 @@
+const TRAIL_LEN = 5;
+const trails = [];
+
+function updateTrails(hands = []) {
+  for (let i = 0; i < hands.length; i++) {
+    const lm = hands[i];
+    if (!trails[i]) trails[i] = [];
+    if (lm && lm[20]) {
+      const t = trails[i];
+      t.push({ x: lm[20].x, y: lm[20].y });
+      if (t.length > TRAIL_LEN) t.shift();
+    } else {
+      trails[i] = [];
+    }
+  }
+  trails.length = hands.length;
+}
+
+function detectJ(trail = []) {
+  if (trail.length < TRAIL_LEN) return false;
+  const first = trail[0];
+  const mid = trail[2];
+  const last = trail[trail.length - 1];
+  const down = mid.y - first.y > 0.05;
+  const left = last.x - mid.x < -0.05;
+  const up = last.y - mid.y < -0.02;
+  return down && left && up;
+}
+
+function detectZ(trail = []) {
+  if (trail.length < TRAIL_LEN) return false;
+  const p1 = trail[1];
+  const p2 = trail[2];
+  const p3 = trail[3];
+  const horiz1 = Math.abs(p1.y - trail[0].y) < 0.05 && p1.x > trail[0].x;
+  const diag = p2.x < p1.x && p2.y > p1.y;
+  const horiz2 = Math.abs(p3.y - p2.y) < 0.05 && p3.x > p2.x;
+  return horiz1 && diag && horiz2;
+}
+
+function detectDynamicSigns() {
+  return trails.map(tr => {
+    if (detectJ(tr)) { tr.length = 0; return 'J'; }
+    if (detectZ(tr)) { tr.length = 0; return 'Z'; }
+    return null;
+  });
+}
+
+function resetTrails() { trails.forEach((t, i) => trails[i] = []); }
+
+module.exports = { updateTrails, detectDynamicSigns, resetTrails, detectJ, detectZ };

--- a/src/dynamicSigns.js
+++ b/src/dynamicSigns.js
@@ -1,0 +1,57 @@
+// Track pinky finger trajectories to detect dynamic letters like J and Z.
+// Each hand maintains a short trail of the pinky tip across frames.
+
+const TRAIL_LEN = 5; // number of frames to keep
+const trails = [];
+
+export function updateTrails(hands = []) {
+  for (let i = 0; i < hands.length; i++) {
+    const lm = hands[i];
+    if (!trails[i]) trails[i] = [];
+    if (lm && lm[20]) {
+      const t = trails[i];
+      t.push({ x: lm[20].x, y: lm[20].y });
+      if (t.length > TRAIL_LEN) t.shift();
+    } else {
+      trails[i] = [];
+    }
+  }
+  trails.length = hands.length;
+}
+
+export function detectJ(trail = []) {
+  if (trail.length < TRAIL_LEN) return false;
+  const first = trail[0];
+  const mid = trail[2];
+  const last = trail[trail.length - 1];
+  const down = mid.y - first.y > 0.05;
+  const left = last.x - mid.x < -0.05;
+  const up = last.y - mid.y < -0.02;
+  return down && left && up;
+}
+
+export function detectZ(trail = []) {
+  if (trail.length < TRAIL_LEN) return false;
+  const p1 = trail[1];
+  const p2 = trail[2];
+  const p3 = trail[3];
+  const horiz1 = Math.abs(p1.y - trail[0].y) < 0.05 && p1.x > trail[0].x;
+  const diag = p2.x < p1.x && p2.y > p1.y;
+  const horiz2 = Math.abs(p3.y - p2.y) < 0.05 && p3.x > p2.x;
+  return horiz1 && diag && horiz2;
+}
+
+export function detectDynamicSigns() {
+  return trails.map(tr => {
+    if (detectJ(tr)) { tr.length = 0; return 'J'; }
+    if (detectZ(tr)) { tr.length = 0; return 'Z'; }
+    return null;
+  });
+}
+
+export function resetTrails() { trails.forEach((t, i) => trails[i] = []); }
+
+// Support CommonJS for tests
+if (typeof module !== 'undefined') {
+  module.exports = { updateTrails, detectDynamicSigns, resetTrails, detectJ, detectZ };
+}


### PR DESCRIPTION
## Summary
- implement `dynamicSigns` module for trajectory-based gesture detection
- support commonjs build and tests
- integrate dynamic detection loop in `app.js`
- add unit tests for detecting J and Z movements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c4dc84348331b2c29f40663b5e0b