### PR TITLE
Add heuristics for letters K–Z

### DIFF
--- a/__tests__/staticSigns.test.js
+++ b/__tests__/staticSigns.test.js
@@ -148,4 +148,46 @@ describe('detectStaticSign', () => {
     lm[4].x = -1; lm[20].x = 2; lm[20].y = -1;
     expect(detectStaticSign(lm)).toBe('Y');
   });
+
+  test('recognizes sign P with thumb, index and ring', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[8].y = -1; lm[16].y = -1;
+    expect(detectStaticSign(lm)).toBe('P');
+  });
+
+  test('recognizes sign Q with thumb, index and pinky', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[8].y = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('Q');
+  });
+
+  test('recognizes sign R with index, middle and pinky', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[12].y = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('R');
+  });
+
+  test('recognizes sign S with last three fingers', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[16].y = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('S');
+  });
+
+  test('recognizes sign T with middle and pinky over thumb', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[12].y = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('T');
+  });
+
+  test('recognizes sign X with index and ring extended', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[16].y = -1;
+    expect(detectStaticSign(lm)).toBe('X');
+  });
+
+  test('recognizes sign Z with index, ring and pinky', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[16].y = -1; lm[20].y = -1;
+    expect(detectStaticSign(lm)).toBe('Z');
+  });
 });

--- a/src/staticSigns.cjs
+++ b/src/staticSigns.cjs
@@ -39,6 +39,13 @@ function detectStaticSign(lm) {
   if (indexExt && middleExt && ringExt && !thumbExt && !pinkExt) return 'W';
   if (thumbExt && !indexExt && !middleExt && !ringExt && pinkExt &&
       dist(lm[4], lm[20]) > 1.5) return 'Y';
+  if (indexExt && ringExt && thumbExt && !middleExt && !pinkExt) return 'P';
+  if (indexExt && pinkExt && thumbExt && !middleExt && !ringExt) return 'Q';
+  if (indexExt && middleExt && pinkExt && !ringExt && !thumbExt) return 'R';
+  if (!indexExt && !middleExt && ringExt && pinkExt && thumbExt) return 'S';
+  if (!indexExt && middleExt && !ringExt && pinkExt && thumbExt) return 'T';
+  if (indexExt && ringExt && !middleExt && !pinkExt && !thumbExt) return 'X';
+  if (indexExt && ringExt && pinkExt && !middleExt && !thumbExt) return 'Z';
   return null;
 }
 

--- a/src/staticSigns.js
+++ b/src/staticSigns.js
@@ -38,6 +38,13 @@ export function detectStaticSign(lm) {
   if (indexExt && middleExt && ringExt && !thumbExt && !pinkExt) return 'W';
   if (thumbExt && !indexExt && !middleExt && !ringExt && pinkExt &&
       dist(lm[4], lm[20]) > 1.5) return 'Y';
+  if (indexExt && ringExt && thumbExt && !middleExt && !pinkExt) return 'P';
+  if (indexExt && pinkExt && thumbExt && !middleExt && !ringExt) return 'Q';
+  if (indexExt && middleExt && pinkExt && !ringExt && !thumbExt) return 'R';
+  if (!indexExt && !middleExt && ringExt && pinkExt && thumbExt) return 'S';
+  if (!indexExt && middleExt && !ringExt && pinkExt && thumbExt) return 'T';
+  if (indexExt && ringExt && !middleExt && !pinkExt && !thumbExt) return 'X';
+  if (indexExt && ringExt && pinkExt && !middleExt && !thumbExt) return 'Z';
   return null;
 }
 


### PR DESCRIPTION
## Summary
- extend sign detection to cover letters P–Z
- test new letters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c509e7108331a10594a2fe926456