### PR TITLE
Implement automatic LSA translation

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -31,6 +31,11 @@ beforeAll(() => {
     localStorage.setItem('haptics', hapticsToggle.checked.toString());
   });
 
+  const autoToggle = document.getElementById('autoTranslateToggle');
+  autoToggle.addEventListener('click', () => {
+    localStorage.setItem('autoTranslate', autoToggle.checked.toString());
+  });
+
   const helpBtn = document.getElementById('helpBtn');
   const helpPanel = document.getElementById('helpPanel');
   function toggleHelp(show) {
@@ -138,6 +143,15 @@ describe('index.html', () => {
     expect(localStorage.getItem('haptics')).toBe('false');
     toggle.click();
     expect(localStorage.getItem('haptics')).toBe('true');
+  });
+
+  test('auto translate toggle saves preference', () => {
+    const toggle = document.getElementById('autoTranslateToggle');
+    localStorage.clear();
+    toggle.click();
+    expect(localStorage.getItem('autoTranslate')).toBe('false');
+    toggle.click();
+    expect(localStorage.getItem('autoTranslate')).toBe('true');
   });
 
   test('camera menu lists available cameras', async () => {

--- a/__tests__/lsaTranslate.test.js
+++ b/__tests__/lsaTranslate.test.js
@@ -1,0 +1,19 @@
+const requireEsm = require('esm')(module);
+const { createTranslator } = requireEsm('../src/lsaTranslate.js');
+
+describe('LSA translator', () => {
+  test('accumulates letters after stable detection', () => {
+    const out = { textContent: '' };
+    const t = createTranslator(out);
+    t.processFrame('A', 0);
+    t.processFrame('A', 50);
+    t.processFrame('A', 100); // stable for 3 frames
+    expect(out.textContent).toBe('A');
+    t.processFrame(null, 150); // start gap
+    t.processFrame(null, 500);
+    t.processFrame(null, 950);
+    t.processFrame(null, 1000); // >800ms since last letter
+    expect(out.textContent).toBe('A ');
+    expect(t.getBuffer()).toBe('A ');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
           <div class="settings-item"><div class="item-label">Fuente de subtítulos</div><div class="item-control"><select id="subtitleFontSelect"><option value="sans-serif">Sans</option><option value="serif">Serif</option><option value="monospace">Mono</option></select></div></div>
           <div class="settings-item"><div class="item-label">Color de subtítulos</div><div class="item-control"><input type="color" id="subtitleColorInput" value="#ffffff"></div></div>
           <div class="settings-item"><div class="item-label">Vibración</div><label class="toggle-switch"><input type="checkbox" id="hapticsToggle" checked><span class="slider"></span></label></div>
+          <div class="settings-item"><div class="item-label">Traducción automática</div><label class="toggle-switch"><input type="checkbox" id="autoTranslateToggle" checked><span class="slider"></span></label></div>
           <div class="settings-item"><div class="item-label">Alto contraste</div><label class="toggle-switch"><input type="checkbox" id="contrastToggle"><span class="slider"></span></label></div>
         </div>
       </div>

--- a/src/app.js
+++ b/src/app.js
@@ -36,6 +36,7 @@ const resetPrefsBtn = document.getElementById('resetPrefsBtn');
 const downloadSttBtn = document.getElementById('downloadSttBtn');
 const lsaSettingsBtn = document.getElementById('lsaSettingsBtn');
 const hapticsToggle = document.getElementById('hapticsToggle');
+const autoTranslateToggle = document.getElementById('autoTranslateToggle');
 const video = document.getElementById('video');
 const fallbackCam = document.getElementById('fallbackCam');
 const fallbackSpeech = document.getElementById('fallbackSpeech');
@@ -61,7 +62,7 @@ const { savedCamera, savedMic } = initSettings({
   subtitleFontSelect, subtitleColorInput,
   dialectSelect, cameraSelect, micSelect,
   repeatTourBtn, resetPrefsBtn, downloadSttBtn,
-  lsaSettingsBtn, hapticsToggle, captionContainer,
+  lsaSettingsBtn, hapticsToggle, autoTranslateToggle, captionContainer,
   startTour, startStream
 });
 
@@ -199,4 +200,6 @@ Promise.all(tasks).then(() => {
     video,
     canvas: document.getElementById('trackerCanvas')
   });
+  const { initLsaTranslate } = await import('./lsaTranslate.js');
+  initLsaTranslate({ captionText });
 })();

--- a/src/lsaTranslate.js
+++ b/src/lsaTranslate.js
@@ -1,35 +1,73 @@
 import { detectStaticSign } from './staticSigns.js';
-import { trackerState } from './tracker.js';
 import { getAutoTranslateEnabled } from './settings.js';
+
+export function createTranslator(outEl) {
+  let buffer = '';
+  let lastSign = null;
+  let stableSign = null;
+  let stableCount = 0;
+  let lastTime = 0;
+
+  function updateOutput() {
+    if (outEl) outEl.textContent = buffer;
+  }
+
+  function append(letter, now) {
+    buffer += letter;
+    updateOutput();
+    lastTime = now;
+  }
+
+  function processFrame(sign, now = (typeof performance !== 'undefined' ? performance.now() : Date.now())) {
+    if (sign === stableSign) {
+      stableCount += 1;
+    } else {
+      stableSign = sign;
+      stableCount = 1;
+    }
+    if (stableCount >= 3 && sign !== lastSign) {
+      if (sign) {
+        append(sign, now);
+      } else if (now - lastTime > 800 && buffer && buffer[buffer.length - 1] !== ' ') {
+        append(' ', now);
+      }
+      lastSign = sign;
+    }
+  }
+
+  function clear() {
+    buffer = '';
+    updateOutput();
+    lastSign = stableSign = null;
+    stableCount = 0;
+  }
+
+  function getBuffer() {
+    return buffer;
+  }
+
+  return { processFrame, clear, getBuffer };
+}
 
 export function initLsaTranslate({ captionText } = {}) {
   const outEl = captionText || document.getElementById('captionText');
-  let buffer = '';
-  let lastSign = null;
-  let lastTime = 0;
+  const { processFrame } = createTranslator(outEl);
+  let trackerState = null;
+
+  import('./tracker.js').then(m => { trackerState = m.trackerState; });
 
   function loop(now) {
-    const enabled = getAutoTranslateEnabled();
-    if (!enabled) {
+    if (!getAutoTranslateEnabled()) {
       requestAnimationFrame(loop);
       return;
     }
     let sign = null;
-    for (const lm of trackerState.handLandmarks) {
+    const hands = trackerState ? trackerState.handLandmarks : [];
+    for (const lm of hands) {
       sign = detectStaticSign(lm);
       if (sign) break;
     }
-    if (sign !== lastSign) {
-      if (sign) {
-        buffer += sign;
-        if (outEl) outEl.textContent = buffer;
-        lastTime = now;
-      } else if (now - lastTime > 800 && buffer && buffer[buffer.length - 1] !== ' ') {
-        buffer += ' ';
-        if (outEl) outEl.textContent = buffer;
-      }
-      lastSign = sign;
-    }
+    processFrame(sign, now);
     requestAnimationFrame(loop);
   }
 

--- a/src/lsaTranslate.js
+++ b/src/lsaTranslate.js
@@ -1,0 +1,37 @@
+import { detectStaticSign } from './staticSigns.js';
+import { trackerState } from './tracker.js';
+import { getAutoTranslateEnabled } from './settings.js';
+
+export function initLsaTranslate({ captionText } = {}) {
+  const outEl = captionText || document.getElementById('captionText');
+  let buffer = '';
+  let lastSign = null;
+  let lastTime = 0;
+
+  function loop(now) {
+    const enabled = getAutoTranslateEnabled();
+    if (!enabled) {
+      requestAnimationFrame(loop);
+      return;
+    }
+    let sign = null;
+    for (const lm of trackerState.handLandmarks) {
+      sign = detectStaticSign(lm);
+      if (sign) break;
+    }
+    if (sign !== lastSign) {
+      if (sign) {
+        buffer += sign;
+        if (outEl) outEl.textContent = buffer;
+        lastTime = now;
+      } else if (now - lastTime > 800 && buffer && buffer[buffer.length - 1] !== ' ') {
+        buffer += ' ';
+        if (outEl) outEl.textContent = buffer;
+      }
+      lastSign = sign;
+    }
+    requestAnimationFrame(loop);
+  }
+
+  requestAnimationFrame(loop);
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,8 +1,12 @@
 import { ripple } from './utils.js';
 
 export let hapticsEnabled = true;
+export let autoTranslateEnabled = true;
 export function getHapticsEnabled(){
   return hapticsEnabled;
+}
+export function getAutoTranslateEnabled(){
+  return autoTranslateEnabled;
 }
 
 export function initSettings(refs){
@@ -13,7 +17,7 @@ export function initSettings(refs){
     subtitleFontSelect, subtitleColorInput,
     dialectSelect, cameraSelect, micSelect,
     repeatTourBtn, resetPrefsBtn, downloadSttBtn,
-    lsaSettingsBtn, hapticsToggle, captionContainer,
+    lsaSettingsBtn, hapticsToggle, autoTranslateToggle, captionContainer,
     startTour, startStream
   } = refs;
 
@@ -62,6 +66,12 @@ export function initSettings(refs){
     if (hapticsToggle) hapticsToggle.checked = false;
   }
 
+  const savedAuto = localStorage.getItem('autoTranslate');
+  if (savedAuto === 'false') {
+    autoTranslateEnabled = false;
+    if (autoTranslateToggle) autoTranslateToggle.checked = false;
+  }
+
   settingsBtn.onclick = e => {
     ripple(e, settingsBtn);
     settingsScreen.classList.add('show');
@@ -91,6 +101,13 @@ export function initSettings(refs){
     ripple(e, hapticsToggle);
     hapticsEnabled = hapticsToggle.checked;
     localStorage.setItem('haptics', hapticsEnabled);
+  };
+
+  if (autoTranslateToggle) autoTranslateToggle.onclick = e => {
+    ripple(e, autoTranslateToggle);
+    autoTranslateEnabled = autoTranslateToggle.checked;
+    localStorage.setItem('autoTranslate', autoTranslateEnabled);
+    window.dispatchEvent(new Event('autotranslatechange'));
   };
 
   subtitleSizeSlider.oninput = () => {


### PR DESCRIPTION
## Summary
- implement `lsaTranslate.js` for combining detected letters into words
- display toggle in settings for enabling automatic translation
- track preference in `settings.js` and expose helper
- initialize translator from `app.js`
- update tests for new toggle

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c4f39d588331901277361a42208d