### PR TITLE
Add STT cache controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Para ejecutar la demo sin conexión:
 Dentro de la pantalla de configuraciones se incluye un botón para descargar el
 modelo de transcripción de audio directamente al caché del navegador. El
 progreso se muestra sobre el botón y, una vez completado, la aplicación puede
-funcionar sin conexión.
+funcionar sin conexión. Si desea liberar espacio, utilice el botón **Eliminar**
+para borrar estos modelos del caché.
 
 ### PWA Installation
 
@@ -207,6 +208,7 @@ npm run prepare-offline
 ```
 
 Esto descargará los modelos actualizados y sobrescribirá la carpeta `libs/`. Tras el despliegue, puede limpiar la caché `offline-models` desde las herramientas de desarrollo o esperar a que el nuevo service worker la renueve.
+También es posible eliminar manualmente los modelos descargados desde la pantalla de configuraciones usando el botón **Eliminar**.
 
 ### Actualizaciones automáticas con Dependabot
 

--- a/__tests__/clearCache.test.js
+++ b/__tests__/clearCache.test.js
@@ -1,0 +1,30 @@
+describe('service worker cache deletion', () => {
+  let handlers;
+  let store;
+  beforeEach(() => {
+    jest.resetModules();
+    handlers = {};
+    store = new Map();
+    global.self = {
+      addEventListener: (evt, cb) => { handlers[evt] = cb; },
+      skipWaiting: jest.fn(),
+      clients: { claim: jest.fn() }
+    };
+    const cache = {
+      delete: jest.fn(key => { store.delete(key); return Promise.resolve(true); }),
+      put: jest.fn((k,v) => { store.set(k,v); return Promise.resolve(); })
+    };
+    global.caches = {
+      open: jest.fn().mockResolvedValue(cache),
+    };
+    global.self.location = { origin: 'http://localhost' };
+    require('../sw.js');
+    global._cache = cache;
+  });
+
+  test('deletes entry from offline-models cache', async () => {
+    await handlers.message({ data: { type: 'DELETE_MODEL', url: 'foo' }, waitUntil: p => p });
+    expect(global.caches.open).toHaveBeenCalledWith('offline-models');
+    expect(global._cache.delete).toHaveBeenCalledWith('foo');
+  });
+});

--- a/sw.js
+++ b/sw.js
@@ -68,7 +68,15 @@ self.addEventListener('fetch', evt => {
 });
 
 self.addEventListener('message', evt => {
-  if (evt.data === 'SKIP_WAITING') self.skipWaiting();
+  if (evt.data === 'SKIP_WAITING') {
+    self.skipWaiting();
+    return;
+  }
+  if (evt.data && evt.data.type === 'DELETE_MODEL' && evt.data.url) {
+    evt.waitUntil(
+      caches.open(MODEL_CACHE).then(cache => cache.delete(evt.data.url))
+    );
+  }
 });
 
 async function cacheFirst(request) {


### PR DESCRIPTION
## Summary
- add ability to remove STT model from settings
- announce download progress via ARIA live region
- allow service worker to delete models on request
- document model removal workflow
- test service worker cache deletion

## Testing
- `npm test`
- `npm run lint` *(fails: 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854c52ceb788331b53df546323d073c