### PR TITLE
Add full alphabet sign detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ transcription directly in the browser.
 * Interfaz con subtítulos arrastrables, cambio de tema y recorrido guiado.
 * Las preferencias de tema y tamaño de subtítulos se guardan en el navegador.
 * Herramientas para capturar imágenes y alternar cámaras durante la sesión.
-* Reconocimiento de señas estáticas **A–J** sin conexión.
+* Reconocimiento de señas estáticas **A–Z** sin conexión.
 
 ## Architecture
 

--- a/__tests__/staticSigns.test.js
+++ b/__tests__/staticSigns.test.js
@@ -148,4 +148,54 @@ describe('detectStaticSign', () => {
     lm[4].x = -1; lm[20].x = 2; lm[20].y = -1;
     expect(detectStaticSign(lm)).toBe('Y');
   });
+
+  test('recognizes sign P with downward index and middle', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[4].y = 1; // thumb
+    lm[12].x = -1; lm[12].y = 1;
+    expect(detectStaticSign(lm)).toBe('P');
+  });
+
+  test('recognizes sign Q like downward G', () => {
+    const lm = baseHand();
+    lm[4].x = -1; lm[4].y = 1; // thumb
+    lm[8].x = -1; lm[8].y = 1;
+    expect(detectStaticSign(lm)).toBe('Q');
+  });
+
+  test('recognizes sign R with crossed fingers', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[12].y = -1;
+    lm[8].x = 0; lm[12].x = 0;
+    lm[4].x = 0.1; lm[4].y = -1;
+    expect(detectStaticSign(lm)).toBe('R');
+  });
+
+  test('recognizes sign S with fist and thumb over fingers', () => {
+    const lm = baseHand();
+    lm[4].x = 0; lm[4].y = 1;
+    lm[12].x = 0.5;
+    expect(detectStaticSign(lm)).toBe('S');
+  });
+
+  test('recognizes sign T with thumb between index and middle', () => {
+    const lm = baseHand();
+    lm[4].x = 0; lm[4].y = 1;
+    lm[8].x = 0; lm[8].y = 1;
+    lm[12].x = 0; lm[12].y = 1;
+    expect(detectStaticSign(lm)).toBe('T');
+  });
+
+  test('recognizes sign X with hooked index', () => {
+    const lm = baseHand();
+    lm[4].x = 1; // thumb not extended
+    lm[8].y = 0.05;
+    expect(detectStaticSign(lm)).toBe('X');
+  });
+
+  test('recognizes sign Z with horizontal index', () => {
+    const lm = baseHand();
+    lm[8].y = -1; lm[8].x = 2;
+    expect(detectStaticSign(lm)).toBe('Z');
+  });
 });

--- a/src/staticSigns.cjs
+++ b/src/staticSigns.cjs
@@ -7,6 +7,9 @@ function detectStaticSign(lm) {
   const middleExt = ext(12);
   const ringExt = ext(16);
   const pinkExt = ext(20);
+  const indexDown = lm[8].y > lm[6].y;
+  const middleDown = lm[12].y > lm[10].y;
+  const near = (a, b, t = 0.1) => dist(a, b) < t;
 
   // New letters F-J
   if (indexExt && middleExt && ringExt && pinkExt && thumbExt &&
@@ -23,10 +26,28 @@ function detectStaticSign(lm) {
 
   if (!indexExt && !middleExt && !ringExt && pinkExt && thumbExt &&
       dist(lm[4], lm[20]) <= 1.5) return 'J';
+
+  // Additional letters handled below
+  if (indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      (lm[8].x - lm[6].x) > 1) return 'Z';
+  if (thumbExt && indexDown && middleDown && !ringExt && !pinkExt &&
+      near(lm[4], lm[12])) return 'P';
+  if (thumbExt && indexDown && !middleExt && !ringExt && !pinkExt &&
+      near(lm[4], lm[8])) return 'Q';
   if (!indexExt && !middleExt && !ringExt && !pinkExt && thumbExt) return 'A';
   if (indexExt && middleExt && ringExt && pinkExt && !thumbExt) return 'B';
+  if (indexExt && middleExt && !ringExt && !pinkExt && !thumbExt && sepIM < 0.05 &&
+      near(lm[4], lm[8], 0.2))
+    return 'R';
   if (indexExt && middleExt && !ringExt && !pinkExt) return 'C';
   if (indexExt && !middleExt && !ringExt && !pinkExt) return 'D';
+  if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      near(lm[4], lm[8]) && !near(lm[4], lm[12])) return 'S';
+  if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      near(lm[4], lm[8], 0.05) && near(lm[4], lm[12], 0.05)) return 'T';
+  if (!indexExt && indexDown && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      near(lm[8], lm[6], 0.1))
+    return 'X';
   if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt) return 'E';
 
   if (indexExt && thumbExt && !middleExt && !ringExt && !pinkExt &&
@@ -39,6 +60,7 @@ function detectStaticSign(lm) {
   if (indexExt && middleExt && ringExt && !thumbExt && !pinkExt) return 'W';
   if (thumbExt && !indexExt && !middleExt && !ringExt && pinkExt &&
       dist(lm[4], lm[20]) > 1.5) return 'Y';
+
   return null;
 }
 

--- a/src/staticSigns.js
+++ b/src/staticSigns.js
@@ -7,6 +7,9 @@ export function detectStaticSign(lm) {
   const middleExt = ext(12);
   const ringExt = ext(16);
   const pinkExt = ext(20);
+  const indexDown = lm[8].y > lm[6].y;
+  const middleDown = lm[12].y > lm[10].y;
+  const near = (a, b, t = 0.1) => dist(a, b) < t;
 
   // New letters F-J
   if (indexExt && middleExt && ringExt && pinkExt && thumbExt &&
@@ -22,10 +25,28 @@ export function detectStaticSign(lm) {
   // pose where the pinky and thumb are extended.
   if (!indexExt && !middleExt && !ringExt && pinkExt && thumbExt &&
       dist(lm[4], lm[20]) <= 1.5) return 'J';
+
+  // Additional letters handled below
+  if (indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      (lm[8].x - lm[6].x) > 1) return 'Z';
+  if (thumbExt && indexDown && middleDown && !ringExt && !pinkExt &&
+      near(lm[4], lm[12])) return 'P';
+  if (thumbExt && indexDown && !middleExt && !ringExt && !pinkExt &&
+      near(lm[4], lm[8])) return 'Q';
   if (!indexExt && !middleExt && !ringExt && !pinkExt && thumbExt) return 'A';
   if (indexExt && middleExt && ringExt && pinkExt && !thumbExt) return 'B';
+  if (indexExt && middleExt && !ringExt && !pinkExt && !thumbExt && sepIM < 0.05 &&
+      near(lm[4], lm[8], 0.2))
+    return 'R';
   if (indexExt && middleExt && !ringExt && !pinkExt) return 'C';
   if (indexExt && !middleExt && !ringExt && !pinkExt) return 'D';
+  if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      near(lm[4], lm[8]) && !near(lm[4], lm[12])) return 'S';
+  if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      near(lm[4], lm[8], 0.05) && near(lm[4], lm[12], 0.05)) return 'T';
+  if (!indexExt && indexDown && !middleExt && !ringExt && !pinkExt && !thumbExt &&
+      near(lm[8], lm[6], 0.1))
+    return 'X';
   if (!indexExt && !middleExt && !ringExt && !pinkExt && !thumbExt) return 'E';
 
   if (indexExt && thumbExt && !middleExt && !ringExt && !pinkExt &&
@@ -38,6 +59,7 @@ export function detectStaticSign(lm) {
   if (indexExt && middleExt && ringExt && !thumbExt && !pinkExt) return 'W';
   if (thumbExt && !indexExt && !middleExt && !ringExt && pinkExt &&
       dist(lm[4], lm[20]) > 1.5) return 'Y';
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- implement detection for P,Q,R,S,T,X,Z
- port changes to CommonJS build
- test all new static signs
- document alphabet coverage

## Testing
- `npm run lint` *(fails: no-unused-vars etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c51d70808331ade453ec34befc43