### PR TITLE
Handle PCM array in transcribe worker

### DIFF
--- a/__tests__/transcribeWorker.test.js
+++ b/__tests__/transcribeWorker.test.js
@@ -11,29 +11,18 @@ beforeEach(() => {
   jest.resetModules();
   global.TextEncoder = TextEncoder;
   global.TextDecoder = TextDecoder;
-  global.Blob = require('buffer').Blob;
   fs.mkdirSync(libsDir, { recursive: true });
   fs.writeFileSync(stubPath, stubContent);
   global.self = { navigator: {}, postMessage: jest.fn() };
-  global.AudioContext = class {
-    async decodeAudioData() {
-      return {
-        sampleRate: 16000,
-        duration: 0,
-        getChannelData: () => Float32Array.from([0, 0.1])
-      };
-    }
-    close() {}
-  };
 });
 
 afterEach(() => {
   if (fs.existsSync(stubPath)) fs.unlinkSync(stubPath);
 });
 
-test('posting audio blob returns transcribed text', async () => {
+test('posting pcm array returns transcribed text', async () => {
   await requireEsm('../src/transcribeWorker.js');
-  const blob = new Blob([Uint8Array.from([0,1,2])], { type: 'audio/webm' });
-  await global.self.onmessage({ data: blob });
+  const pcm = Float32Array.from([0, 0.1]);
+  await global.self.onmessage({ data: pcm });
   expect(global.self.postMessage).toHaveBeenCalledWith('Hola mundo');
 });

--- a/src/mic.js
+++ b/src/mic.js
@@ -120,7 +120,7 @@ export function initMic({ SR, micBtn, captionContainer, captionText, micSelect, 
       setProgress(progress,35);
       if(worker){
         const p=new Promise(r=>{worker.onmessage=e=>r(e.data);});
-        worker.postMessage(pcm.buffer,[pcm.buffer]);
+        worker.postMessage(pcm,[pcm.buffer]);
         const text=await p;
         captionText.textContent=text;
         setProgress(progress,100);

--- a/src/transcribeWorker.js
+++ b/src/transcribeWorker.js
@@ -13,31 +13,8 @@ async function ensurePipeline() {
   return transcriber;
 }
 
-async function blobToPCM(blob, rate = 16000) {
-  const ac = new AudioContext();
-  let off;
-  try {
-    const buf = await blob.arrayBuffer();
-    const dec = await ac.decodeAudioData(buf);
-    if (dec.sampleRate === rate) {
-      return dec.getChannelData(0).slice();
-    }
-    const frames = Math.ceil(dec.duration * rate);
-    off = new OfflineAudioContext(1, frames, rate);
-    const src = off.createBufferSource();
-    src.buffer = dec;
-    src.connect(off.destination);
-    src.start();
-    const res = await off.startRendering();
-    off.close && off.close();
-    return res.getChannelData(0).slice();
-  } finally {
-    ac.close();
-  }
-}
-
 self.onmessage = async e => {
-  const pcm = await blobToPCM(e.data);
+  const pcm = e.data;
   const p = await ensurePipeline();
   const { text } = await (await p)(pcm, { chunk_length_s: 30, language: 'spanish' });
   self.postMessage(text.trim());


### PR DESCRIPTION
## Summary
- simplify `transcribeWorker` to accept a Float32Array directly
- send typed arrays to worker instead of ArrayBuffers
- adapt worker tests for new input API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854d64be8ec83319fcbcb8a092200be