### PR TITLE
Fix duplicate Architecture header

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ npm test
 This runs the Jest test suite which verifies that `index.html` loads and key
 elements such as the video and canvas are present.
 
-## Architecture
-
-For an overview of the core modules and how the service worker cachés offline
-resources, see [docs/architecture.md](docs/architecture.md).
 
 ## Dependencias e instalación
 


### PR DESCRIPTION
## Summary
- remove the repeated `Architecture` section from README

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854dd730d5483318fe22c2781291f3c