### PR TITLE
Add THIRD_PARTY_LICENSES and reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ Para revisarlas y fusionarlas:
 
 Los planes para la siguiente iteración se describen en [docs/next-sprint.md](docs/next-sprint.md). Este objetivo ambicioso busca ampliar el vocabulario de señas y mejorar la experiencia sin conexión.
 
+## Licenses
+
+For information on external libraries such as **MediaPipe** and **HuggingFace Transformers**, see [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).
+
 ## Política de Privacidad
 
 La aplicación procesa video y audio localmente en su navegador. No se envían datos de cámara ni micrófono a servidores externos. Para más detalles consulte [docs/privacy.md](docs/privacy.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,12 @@
+# Third-Party Licenses
+
+This project includes a few external libraries. The following packages are distributed under the terms of the **Apache License 2.0**:
+
+- MediaPipe Hands
+- MediaPipe Face Mesh
+- MediaPipe Pose
+- MediaPipe Drawing Utils
+- HuggingFace Transformers
+- onnxruntime-web
+
+Please refer to the original projects for the full license texts.


### PR DESCRIPTION
## Summary
- add `THIRD_PARTY_LICENSES.md` with Apache-2.0 info for MediaPipe, transformers, and onnxruntime-web
- mention the file under a new "Licenses" section in `README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ea37b960833182fe46310bb691fe