### PR TITLE
Add license notice for Transformers.js

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,23 @@
+# Third Party Licenses
+
+This project bundles an offline copy of **Transformers.js**, version 3.5.2.
+The original distribution is published by Hugging Face under the Apache License 2.0.
+Below is the license notice extracted from the upstream bundle:
+
+```
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+```


### PR DESCRIPTION
## Summary
- include the Apache license header for the bundled `transformers.min.js` in a new `THIRD_PARTY_LICENSES.md`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6854ea9a6fe48331b6c42cb90609e928