### PR TITLE
PWA store readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+icon-192.png
+icon-512.png

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ minor differences.
 ## Deployment
 
 Para un entorno de producción se recomienda servir la aplicación a través de **HTTPS**. Cualquier servidor estático es suficiente; por ejemplo:
+Para instrucciones sobre empaquetar la PWA para las tiendas móviles consulte [docs/deployment.md](docs/deployment.md).
 
 ```bash
 npx http-server . -p 443 --ssl --cert path/to/cert.pem --key path/to/key.pem

--- a/__tests__/sw.test.js
+++ b/__tests__/sw.test.js
@@ -1,9 +1,14 @@
 beforeEach(() => {
   jest.resetModules();
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.clearAllTimers();
 });
 
+
 test('service worker registers', () => {
-  const register = jest.fn().mockResolvedValue({ addEventListener: jest.fn() });
+  const register = jest.fn().mockResolvedValue({ addEventListener: jest.fn(), update: jest.fn() });
   Object.defineProperty(window, 'navigator', {
     value: { serviceWorker: { register, addEventListener: jest.fn() } },
     configurable: true
@@ -15,7 +20,7 @@ test('service worker registers', () => {
 
 test('prompts when waiting worker present', async () => {
   const postMessage = jest.fn();
-  const register = jest.fn().mockResolvedValue({ waiting: { postMessage }, addEventListener: jest.fn() });
+  const register = jest.fn().mockResolvedValue({ waiting: { postMessage }, addEventListener: jest.fn(), update: jest.fn() });
   Object.defineProperty(window, 'navigator', {
     value: { serviceWorker: { register, addEventListener: jest.fn() } },
     configurable: true
@@ -30,7 +35,7 @@ test('prompts when waiting worker present', async () => {
 
 test('user accepts update posts message and reloads', async () => {
   const postMessage = jest.fn();
-  const register = jest.fn().mockResolvedValue({ waiting: { postMessage }, addEventListener: jest.fn() });
+  const register = jest.fn().mockResolvedValue({ waiting: { postMessage }, addEventListener: jest.fn(), update: jest.fn() });
   let controllerHandler;
   const addEventListener = jest.fn((e, cb) => { if (e === 'controllerchange') controllerHandler = cb; });
   Object.defineProperty(window, 'navigator', {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,13 @@
+# Deploying SeñAR to Mobile Stores
+
+This project can be packaged and submitted to major app stores using **PWABuilder**.
+
+1. Navigate to <https://www.pwabuilder.com/> and enter the URL where the PWA is hosted.
+2. Verify the manifest and service worker pass all tests. Adjust `manifest.json` and `sw.js` if needed.
+   Provide 192x192 and 512x512 icons referenced by the manifest; these are not stored in this repository.
+3. Generate the **Android** package and download the resulting `.aab` file.
+4. Sign the bundle using your keystore and upload it through the **Google Play Console**.
+5. For **iOS**, use the provided instructions to create an App Store package. PWABuilder wraps the PWA using a WebView so it can be submitted through **App Store Connect**.
+6. After publishing, users will receive updates automatically thanks to the service worker.
+
+See the main [README](../README.md#deployment) for generic hosting notes.

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,15 @@
 {
   "name": "SeñAR Web App",
   "short_name": "SeñAR",
+  "id": "com.senar.pwa",
+  "description": "Prototype sign language translator using AR techniques.",
   "start_url": "/index.html",
+  "scope": "/",
   "display": "standalone",
+  "orientation": "portrait",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
+  "categories": ["education", "utilities"],
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/sw-register.js
+++ b/src/sw-register.js
@@ -7,6 +7,10 @@ if ('serviceWorker' in navigator) {
         }
       };
 
+      // Check for updates on load and periodically
+      reg.update();
+      setInterval(() => reg.update(), 60 * 60 * 1000);
+
       if (reg.waiting) {
         promptUpdate(reg.waiting);
       }


### PR DESCRIPTION
## Summary
- extend manifest with store metadata while excluding binary icons
- automatically check for updates in the service worker registration
- document publishing the PWA to mobile stores and note icons must be provided separately
- ignore `node_modules` and icon files in git

## Testing
- `npm test`
- `npm run lint` *(fails: 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854ea8cc1d88331bd31504d3f558b62