### PR TITLE
Improve landing responsiveness

### DIFF
--- a/landing.css
+++ b/landing.css
@@ -132,4 +132,17 @@ h2::after{content:'';display:block;width:60px;height:4px;margin:.5rem auto;backg
   .nav-links.open{display:flex;}
   .burger{display:block;}
 }
+@media(max-width:600px){
+  .hero{padding:4rem 0;}
+  .hero h1{font-size:2.2rem;}
+  .hero p{font-size:1rem;}
+  section{padding:3rem 0;}
+  .timeline-item{flex-direction:column;align-items:center;text-align:center;}
+  .timeline-item::before{margin:0 0 .5rem;}
+  .download-grid{grid-template-columns:1fr;}
+}
+@media(max-width:480px){
+  body{padding-top:64px;}
+  .container{width:95%;}
+}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;}}

--- a/landing.html
+++ b/landing.html
@@ -2,7 +2,7 @@
 <html lang="es" data-theme="light">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>SeñAR – Comunicación sin Barreras en LSA</title>
 <link rel="stylesheet" href="styles.css">
 <link rel="stylesheet" href="landing.css">


### PR DESCRIPTION
## Summary
- add `viewport-fit=cover` to meta viewport in `landing.html`
- tweak `landing.css` with small-screen breakpoints for better layout

## Testing
- `npm run lint` *(fails: no-unused-vars in existing files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685527ea9cf08331b345423124a157a2