### PR TITLE
Fix mobile scroll issue on landing

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -271,7 +271,9 @@
 const qs=s=>document.querySelector(s),qsa=s=>document.querySelectorAll(s);
 
 /* Pre‑loader */
-window.addEventListener('load',()=>document.body.classList.add('loaded'));
+function hidePreloader(){document.body.classList.add('loaded');}
+window.addEventListener('DOMContentLoaded',hidePreloader);
+window.addEventListener('load',hidePreloader);
 
 /* Burger */
 qs('#burger').addEventListener('click',()=>qs('#nav-links').classList.toggle('open'));


### PR DESCRIPTION
## Summary
- prevent preloader from blocking scroll on mobile by hiding it earlier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685529e2b8308331a5b2e457289a372f