### PR TITLE
Update deployment instructions

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,11 +3,18 @@
 This project can be packaged and submitted to major app stores using **PWABuilder**.
 
 1. Navigate to <https://www.pwabuilder.com/> and enter the URL where the PWA is hosted.
-2. Verify the manifest and service worker pass all tests. Adjust `manifest.json` and `sw.js` if needed.
-   Provide 192x192 and 512x512 icons referenced by the manifest; these are not stored in this repository.
-3. Generate the **Android** package and download the resulting `.aab` file.
-4. Sign the bundle using your keystore and upload it through the **Google Play Console**.
-5. For **iOS**, use the provided instructions to create an App Store package. PWABuilder wraps the PWA using a WebView so it can be submitted through **App Store Connect**.
-6. After publishing, users will receive updates automatically thanks to the service worker.
+2. Verify the manifest and service worker pass all tests. Adjust `manifest.json` and `sw.js` if needed. Provide **192x192** and **512x512** icons referenced by the manifest; these icons are not stored in this repository.
+3. Generate the **Android** package and download the `.aab` bundle.
+   - Test the bundle locally with [`bundletool`](https://developer.android.com/studio/command-line/bundletool) or an emulator.
+   - Sign it with your release keystore: `jarsigner -keystore mykey.jks app-release.aab alias`.
+   - Verify the signature using `jarsigner -verify app-release.aab`.
+   - Upload the signed bundle through the **Google Play Console** and complete the store listing (screenshots, privacy policy, content rating).
+   - Review Google's [launch checklist](https://developer.android.com/console/about/guides/releasewithconfidence) to ensure the app meets Play Store requirements.
+4. For **iOS**, follow PWABuilder's instructions to produce an Xcode project.
+   - Open the project in Xcode, set your bundle identifier and select a distribution certificate with a provisioning profile.
+   - Build and archive the app, testing with **TestFlight** when possible.
+   - Submit the archive through **App Store Connect** and provide the required metadata.
+   - Apple's [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) list all submission requirements.
+5. After publishing, updates are delivered automatically thanks to the service worker.
 
 See the main [README](../README.md#deployment) for generic hosting notes.


### PR DESCRIPTION
## Summary
- expand mobile store deployment steps
- include signing, testing and upload guidance
- link official Play Store and App Store requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a0e347c08331b46c42fed8e15a65