### PR TITLE
Update privacy docs and add app link

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,3 +5,9 @@ Esta aplicación utiliza la cámara y el micrófono únicamente para procesar la
 Los modelos de reconocimiento se descargan y almacenan en la caché del navegador para habilitar el modo sin conexión. Puede eliminar estos datos desde las herramientas de desarrollo o borrando el almacenamiento del sitio.
 
 No se recopila información personal ni se comparte con terceros.
+
+## Datos biométricos
+La aplicación analiza rasgos faciales y movimientos de manos solo para la traducción en tiempo real. Estas características biométricas no se almacenan ni se envían a servidores.
+
+## Eliminación segura
+Puede borrar la caché con modelos y configuraciones desde el menú de su navegador o el botón "Resetear preferencias" en la aplicación.

--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
         <li>Activa la voz con el icono de micr&oacute;fono.</li>
         <li>Cambia de c&aacute;mara o micr&oacute;fono desde el men&uacute;, o en <strong>Ajustes</strong>.</li>
         <li>Para repetir el tour guiado, abre <strong>Ajustes</strong> y elige &quot;Repetir tour&quot;.</li>
+        <li><a href="docs/privacy.md" target="_blank">Política de Privacidad</a></li>
       </ul>
     </div>
     <div id="fallbackCam" class="fallback" role="alert">📷 Cámara no disponible</div>


### PR DESCRIPTION
## Summary
- expand privacy policy with biometric data and secure deletion
- link to the privacy policy from the in-app help panel

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858a0de93788331b059dfe68a9ba6fb