### PR TITLE
Add service worker update banner

### DIFF
--- a/src/sw-register.js
+++ b/src/sw-register.js
@@ -1,10 +1,22 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('sw.js').then(reg => {
+      let banner;
+      let waitingWorker;
       const promptUpdate = worker => {
-        if (window.confirm('Update available. Reload?')) {
-          worker.postMessage('SKIP_WAITING');
+        waitingWorker = worker;
+        if (!banner) {
+          banner = document.createElement('div');
+          banner.id = 'updateBanner';
+          banner.className = 'update-banner';
+          banner.innerHTML = '<span>Actualización disponible</span> <button id="updateButton">Actualizar</button>';
+          banner.querySelector('#updateButton').addEventListener('click', () => {
+            if (waitingWorker) waitingWorker.postMessage('SKIP_WAITING');
+            banner.remove();
+          });
+          document.body.appendChild(banner);
         }
+        banner.classList.add('show');
       };
 
       // Check for updates on load and periodically

--- a/styles.css
+++ b/styles.css
@@ -610,3 +610,36 @@ body.light {
         max-width: 95%;
       }
     }
+
+    /* Update banner */
+    #updateBanner {
+      position: fixed;
+      bottom: 16px;
+      left: 50%;
+      transform: translate(-50%, 100%);
+      background: var(--control-bg);
+      color: var(--text-light);
+      padding: 8px 16px;
+      border-radius: var(--radius);
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity var(--transition), transform var(--transition);
+      z-index: 5000;
+    }
+    #updateBanner.show {
+      pointer-events: auto;
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    #updateBanner button {
+      background: var(--accent);
+      color: var(--text-light);
+      border: none;
+      padding: 4px 12px;
+      border-radius: var(--radius);
+      cursor: pointer;
+    }


### PR DESCRIPTION
## Summary
- show toast banner instead of `window.confirm` when a new service worker is waiting
- style new banner in `styles.css`
- update service worker tests for banner logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a0beb50c833194f3e10915aa3c4f