### PR TITLE
Add tilt-based gravity demo

### DIFF
--- a/src/tilt.js
+++ b/src/tilt.js
@@ -1,0 +1,80 @@
+const canvas = document.getElementById('world');
+const ctx = canvas.getContext('2d');
+
+let width = canvas.width = window.innerWidth;
+let height = canvas.height = window.innerHeight;
+
+window.addEventListener('resize', () => {
+  width = canvas.width = window.innerWidth;
+  height = canvas.height = window.innerHeight;
+});
+
+class Body {
+  constructor(x, y, r, color) {
+    this.x = x;
+    this.y = y;
+    this.r = r;
+    this.vx = 0;
+    this.vy = 0;
+    this.color = color;
+  }
+
+  update(gx, gy) {
+    this.vx += gx;
+    this.vy += gy;
+    this.x += this.vx;
+    this.y += this.vy;
+
+    if (this.x - this.r < 0) {
+      this.x = this.r;
+      this.vx *= -0.8;
+    }
+    if (this.x + this.r > width) {
+      this.x = width - this.r;
+      this.vx *= -0.8;
+    }
+    if (this.y - this.r < 0) {
+      this.y = this.r;
+      this.vy *= -0.8;
+    }
+    if (this.y + this.r > height) {
+      this.y = height - this.r;
+      this.vy *= -0.8;
+    }
+  }
+
+  draw() {
+    ctx.beginPath();
+    ctx.fillStyle = this.color;
+    ctx.arc(this.x, this.y, this.r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+const bodies = [
+  new Body(width / 2, height / 2, 20, '#f00'),
+  new Body(width / 2 + 60, height / 2, 15, '#0f0'),
+  new Body(width / 2 - 60, height / 2, 25, '#00f')
+];
+
+let gx = 0, gy = 0;
+const G = 0.2;
+const DEG2RAD = Math.PI / 180;
+
+function handleOrientation(e) {
+  gy = G * Math.sin((e.beta || 0) * DEG2RAD);
+  gx = G * Math.sin((e.gamma || 0) * DEG2RAD);
+}
+
+window.addEventListener('deviceorientation', handleOrientation);
+
+function loop() {
+  ctx.clearRect(0, 0, width, height);
+  for (const b of bodies) {
+    b.update(gx, gy);
+    b.draw();
+  }
+  requestAnimationFrame(loop);
+}
+
+loop();

--- a/tilt.html
+++ b/tilt.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tilt Gravity Demo</title>
+  <style>
+    html,body{margin:0;height:100%;overflow:hidden;background:#000;color:#fff;font-family:sans-serif}
+    canvas{display:block;width:100%;height:100%;background:#222}
+    #info{position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);padding:5px;border-radius:4px}
+  </style>
+</head>
+<body>
+<canvas id="world"></canvas>
+<div id="info">Tilt your device</div>
+<script type="module" src="src/tilt.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `tilt.html` page showcasing a tilt demo
- implement `src/tilt.js` to move objects based on device orientation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c0731474833184a70b8390cd47d7