### PR TITLE
Improve tilt demo behind perspective

### DIFF
--- a/src/tilt.js
+++ b/src/tilt.js
@@ -1,4 +1,5 @@
 const canvas = document.getElementById('world');
+const info = document.getElementById('info');
 const ctx = canvas.getContext('2d');
 
 let width = canvas.width = window.innerWidth;
@@ -60,13 +61,34 @@ const bodies = [
 let gx = 0, gy = 0;
 const G = 0.2;
 const DEG2RAD = Math.PI / 180;
+let behind = false;
+
+function setInfo() {
+  if (info) {
+    info.textContent = behind ? 'Behind view - gravity inverted' : 'Tilt your device';
+  }
+}
 
 function handleOrientation(e) {
-  gy = G * Math.sin((e.beta || 0) * DEG2RAD);
-  gx = G * Math.sin((e.gamma || 0) * DEG2RAD);
+  const beta = e.beta || 0;
+  const gamma = e.gamma || 0;
+  behind = Math.abs(beta) > 90;
+  gy = G * Math.sin(beta * DEG2RAD) * (behind ? -1 : 1);
+  gx = G * Math.sin(gamma * DEG2RAD);
+  setInfo();
 }
 
 window.addEventListener('deviceorientation', handleOrientation);
+
+canvas.addEventListener('pointermove', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = (e.clientX - rect.left) / rect.width - 0.5;
+  const y = (e.clientY - rect.top) / rect.height - 0.5;
+  gx = G * x * 2;
+  gy = G * y * 2;
+  behind = false;
+  setInfo();
+});
 
 function loop() {
   ctx.clearRect(0, 0, width, height);

--- a/tilt.html
+++ b/tilt.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <canvas id="world"></canvas>
-<div id="info">Tilt your device</div>
+<div id="info">Tilt your device - rotate behind to flip gravity</div>
 <script type="module" src="src/tilt.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add info banner element to tilt demo
- invert gravity when device rotates behind the user and update message
- allow pointer-based tilt fallback
- update text in `tilt.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c682a3d4833186ef17c3c0b23739